### PR TITLE
Fix microcontroller type for ItsyBitsy M4 Express

### DIFF
--- a/boards/adafruit_itsybitsy_m4.json
+++ b/boards/adafruit_itsybitsy_m4.json
@@ -6,7 +6,7 @@
       "-DARDUINO_ARCH_SAMD",
       "-DARDUINO_ITSYBITSY_M4",
       "-DADAFRUIT_ITSYBITSY_M4_EXPRESS",
-      "-D__SAMD51J19A__",
+      "-D__SAMD51G19A__",
       "-D__SAMD51__",
       "-D__FPU_PRESENT",
       "-DARM_MATH_CM4",
@@ -30,9 +30,9 @@
     "variant": "itsybitsy_m4"
   },
   "debug": {
-    "jlink_device": "ATSAMD51J19",
-    "openocd_chipname": "at91samd51j19",
-    "svd_path": "ATSAMD51J19A.svd"
+    "jlink_device": "ATSAMD51G19",
+    "openocd_chipname": "at91samd51g19",
+    "svd_path": "ATSAMD51G19A.svd"
   },
   "frameworks": [
     "arduino"


### PR DESCRIPTION
The microcontroller type is wrong: it's not a ATSAMD51J19A but a G19A. The J19A is only in the Metro M4 and Feather M4, according to Adafruit's `board.txt`. The hardware is thus slightly different, having for example a different number of TCs. I'm not entirely sure about the debug section since I'm not using any of those debug devices, but I made what seemed to be the corresponding change. Feel free to correct me if I'm wrong.