### PR TITLE
Create industruino_d21g.json

### DIFF
--- a/boards/industruino_d21g.json
+++ b/boards/industruino_d21g.json
@@ -1,0 +1,55 @@
+{
+  "build": {
+    "core": "samd",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DARDUINO_SAMD_ZERO -DARDUINO_ARCH_SAMD -D__SAMD21G18A__",
+    "f_cpu": "48000000L",
+    "hwids": [
+      [
+        "0x2E78",
+        "0x804D"
+      ],
+      [
+        "0x2E78",
+        "0x004D"
+      ]
+    ],
+    "ldscript": "flash_with_bootloader.ld",
+    "mcu": "samd21g18a",
+    "usb_product": "Industruino D21G",
+    "variant": "industruino_d21g"
+  },
+  "debug": {
+    "jlink_device": "ATSAMD21G18",
+    "onboard_tools": [
+      "cmsis-dap"
+    ],
+    "openocd_chipname": "at91samd21g18",
+    "openocd_target": "at91samdXX",
+    "svd_path": "ATSAMD21G18A.svd"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "Industruino D21G",
+  "upload": {
+    "disable_flushing": true,
+	"native_usb": true,
+    "maximum_ram_size": 32768,
+    "maximum_size": 262144,
+    "offset_address": "0x4000",
+    "protocol": "sam-ba",
+    "protocols": [
+      "sam-ba",
+	  "cmsis-dap",
+      "blackmagic",
+      "jlink",
+      "atmel-ice"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true
+  },
+  "url": "https://industruino.com/page/home",
+  "vendor": "ES Gear Ltd"
+}


### PR DESCRIPTION
Board definition file for Industruino D21G boards. first commit towards - https://github.com/platformio/platform-atmelsam/issues/27

This still has some problems when compiling, variant.h from Industruino does not #define A0
A1, A2 or A3. causing wiring_analogue.c to not compile. Fixed that up in the Variant.h for now by hand
and submitted a bug report to their githubs.

still fails on program & verify
CONFIGURATION: https://docs.platformio.org/page/boards/atmelsam/industruino_d21g.html
PLATFORM: Atmel SAM 3.8.0 > Industruino D21G
HARDWARE: SAMD21G18A 48MHz, 32KB RAM, 256KB Flash
DEBUG: Current (atmel-ice) On-board (cmsis-dap) External (atmel-ice, blackmagic, jlink)
PACKAGES: toolchain-gccarmnoneeabi 1.70201.0 (7.2.1), framework-arduinosam 4.3.190711, tool-bossac 1.10700.190624 (1.7.0)
LDF: Library Dependency Finder -> http://bit.ly/configure-pio-ldf
LDF Modes: Finder ~ chain, Compatibility ~ soft
Found 16 compatible libraries
Scanning dependencies...
Dependency Graph
|-- <Indio> 1.2.0
|   |-- <Wire> 1.0
|-- <UC1701> 1.1.0
|-- <FreeRTOS_SAMD21> 1.0.0
Checking size .pio\build\industruino_d21g\firmware.elf
Memory Usage -> http://bit.ly/pio-memory-usage
DATA:    [=====     ]  52.7% (used 17280 bytes from 32768 bytes)
PROGRAM: [=         ]  10.6% (used 27824 bytes from 262144 bytes)
Configuring upload protocol...
AVAILABLE: atmel-ice, blackmagic, cmsis-dap, jlink, sam-ba
CURRENT: upload_protocol = sam-ba
Looking for upload port...
Auto-detected: COM4
Forcing reset using 1200bps open/close on port COM4
Waiting for the new upload port...
Uploading .pio\build\industruino_d21g\firmware.bin
Atmel SMART device 0x10010005 found
Erase flash
done in 0.828 seconds

Write 27824 bytes to flash (435 pages)
[==============================] 100% (435/435 pages)
done in 0.144 seconds

Verify 27824 bytes of flash with checksum.
Verify failed
*** [upload] Error 2
=================================================================================================== [ERROR] Took 11.27 seconds =================================================================================================== 
The terminal process terminated with exit code: 1