### PR TITLE
Atmel Start Framework builder

### DIFF
--- a/boards/adafruit_feather_m0.json
+++ b/boards/adafruit_feather_m0.json
@@ -31,7 +31,8 @@
     "svd_path": "ATSAMD21G18A.svd"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "atmelstart"
   ],
   "name": "Adafruit Feather M0",
   "upload": {

--- a/boards/moteino_zero.json
+++ b/boards/moteino_zero.json
@@ -26,7 +26,8 @@
     "svd_path": "ATSAMD21G18A.svd"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "atmelstart"
   ],
   "name": "Moteino M0",
   "upload": {

--- a/builder/frameworks/atmelstart.py
+++ b/builder/frameworks/atmelstart.py
@@ -1,0 +1,204 @@
+# AtmelStart Framework build script
+# Author: Frank Leon Rose
+# Copyright (c) 2019
+#
+# Given framework = atmelstart, this builder will look for an
+# `atstart_file = myproject.atstart` line in the Platformio environment.
+# It will use that file to request a package of generated code from
+# Atmel Start (start.atmel.com).
+# Then it will build the env with the generated code files.
+
+import sys
+import os
+import os.path
+import re
+import json
+import requests
+import zipfile
+
+try:
+    import yaml
+except ImportError:
+    env.Execute("$PYTHONEXE -m pip install pyyaml")
+    import yaml
+from yaml import CLoader as Loader
+
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
+
+env = DefaultEnvironment()
+
+env.SConscript("_bare.py")
+
+output_filename = os.path.join(env.subst('$PROJECTBUILD_DIR'), "output.json")
+DOWNLOAD_DIR = os.path.join(env.subst('PROJECTWORKSPACE_DIR'), ".downloads")
+PACKAGES_DIR = os.path.join(env.subst('$PROJECTBUILD_DIR'), "packages")
+
+config = configparser.ConfigParser()
+config.read(env['PROJECT_CONFIG'])
+atstart_file = config.get('env:' + env['PIOENV'], "atstart_file", fallback=None)
+if atstart_file is None:
+    sys.stderr.write("Error: Please specify property `atstart_file = myproject.atstart`.\nThe file is expected to be in the project source directory.\n")
+    env.Exit(1)
+input_filename = os.path.join(env['PROJECTSRC_DIR'], atstart_file)
+if not os.path.isfile(input_filename):
+    sys.stderr.write("Error: atstart_file specifies a non-existent or invalid file: {}\n".format(input_filename))
+    env.Exit(1)
+
+def convert_config_yaml_to_json(input, output):
+    def dictToArray(d, idKey):
+        a = []
+        for (key, value) in d.items():
+            if idKey:
+                value[idKey] = key
+            a.append(value)
+        return a
+
+    def fixDefinition(a):
+        for element in a:
+            element["definition"] = {
+              "identifier": element["definition"],
+              "base": element["definition"]
+            }
+
+    def sort_config(config):
+        config["middlewares"].sort(key=lambda x: x["identifier"])
+        config["drivers"].sort(key=lambda x: x["identifier"])
+        config["pads"].sort(key=lambda x: x["name"])
+
+        # Force order of keys in configuration. Fails to accept configuration without this.
+        sorted_config = {}
+        for key in ['jsonForm', 'formatVersion', 'board', 'identifier', 'name', 'details', 'application', 'middlewares', 'drivers', 'pads']:
+            sorted_config[key] = config[key]
+
+        return sorted_config
+
+    def load_yaml(input_filename):
+        with open(input_filename, "r") as f:
+            config = yaml.load(f, Loader=Loader)
+        config["middlewares"] = dictToArray(config["middlewares"], "identifier")
+        config["drivers"] = dictToArray(config["drivers"], "identifier")
+        config["pads"] = dictToArray(config["pads"], None)
+        config["jsonForm"] = "=1"
+        config["formatVersion"] = 2
+        config["identifier"] = ""
+        fixDefinition(config["drivers"])
+
+        return config
+
+    def load_json(input_filename):
+        with open(input_filename, "r") as f:
+            return json.load(f)
+
+    def dump(config, output_filename, pretty = False):
+        with open(output_filename, "w") as f:
+            indent = 2
+            separators = (',', ': ')
+            if not pretty:
+                indent = None
+                separators = (',', ':')
+            json.dump(config, f, indent=indent, separators=separators, sort_keys=pretty)
+
+    # json_file = load("atmel_start_config.json")
+    config = load_yaml(input)
+    config = sort_config(config)
+    dump(config, output)
+
+def hash_file(file):
+    import hashlib
+    m = hashlib.md5()
+    with open(file, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            m.update(chunk)
+    return m.hexdigest()
+
+def download_package(config_file, download_dir, packages_dir):
+    hash = hash_file(config_file)
+    os.makedirs(download_dir, exist_ok=True)
+    filename = os.path.join(download_dir, hash + '.zip')
+    if os.path.isfile(filename):
+        print('NOTE: Atmel Start package', filename, 'already downloaded. Delete it and re-run if you want to re-download')
+    else:
+        print("Downloading Atmel Start package", filename, "...")
+        with open(config_file, 'r') as project_json:
+            headers = {'content-type': 'text/plain'}
+            r = requests.post('http://start.atmel.com/api/v1/generate/?format=atzip&compilers=[atmel_studio,make]&file_name_base=atmel_start_config', headers=headers, data=project_json)
+        if not r.ok:
+            # Double check that the JSON is minified. If it's not, you'll get a 404.
+            print(r.text)
+            sys.exit(1)
+        with open(filename, 'wb') as out:
+            out.write(r.content)
+
+    package_dir = os.path.join(packages_dir, hash)
+    if not os.path.isdir(package_dir):
+        print("Unzipping ...")
+        z = zipfile.ZipFile(filename)
+        z.extractall(package_dir)
+
+    return package_dir
+
+convert_config_yaml_to_json(input_filename, output_filename)
+package_dir = download_package(output_filename, DOWNLOAD_DIR, PACKAGES_DIR)
+
+def valid_source(p):
+    return "armcc" not in p and "IAR" not in p and "RVDS" not in p
+
+include_paths = []
+source_paths = []
+linker_script = None
+for dirpath, dirnames, filenames in os.walk(package_dir):
+    if valid_source(dirpath):
+        if any(".h" in fn for fn in filenames):
+            include_paths.append(dirpath)
+        if any(".c" in fn for fn in filenames):
+            source_paths.append(dirpath)
+
+    if "gcc" in dirpath:
+        for fn in filenames:
+            if "flash.ld" in fn:
+                linker_script = os.path.realpath(os.path.join(dirpath, fn))
+
+if linker_script is None or not os.path.isfile(linker_script):
+    sys.stderr.write("Error: Failed to find linker script in downloaded package.\n")
+    env.Exit(1)
+
+def adjust_linker_offset(script_name, ldscript):
+    offset_address = env.BoardConfig().get("upload.offset_address", "0")
+    if int(offset_address, 0)==0:
+        return ldscript
+
+    content = ""
+    with open(ldscript) as fp:
+        content = fp.read()
+        # original:     rom      (rx)  : ORIGIN = 0x00000000, LENGTH = 0x00040000
+        # transformed:  rom      (rx)  : ORIGIN = 0x00000000+0x2000, LENGTH = 0x00040000-0x2000
+        content = re.sub(
+            r"^(\s*rom.*ORIGIN[^,]+)(,\s*LENGTH.*)$",
+            r"\1+%s\2-%s" % (offset_address, offset_address),
+            content, flags=re.MULTILINE)
+
+    offset_script = os.path.join(env.subst('$PROJECTBUILD_DIR'),
+                    "%s_flash_%s.ld" % (script_name, offset_address))
+
+    with open(offset_script, "w") as fp:
+        fp.write(content)
+
+    return offset_script
+
+linker_script = adjust_linker_offset(env.subst('$PIOENV'), linker_script)
+env.Replace(LDSCRIPT_PATH=linker_script)
+
+env.Append(CPPPATH=[os.path.realpath(p) for p in include_paths])
+
+sources = ["-<*>"]
+sources.extend(["+<{}>".format(os.path.join(sp, '*.c')) for sp in source_paths])
+sources.append("-<{}>".format('main.c'))
+
+env.BuildSources(
+    os.path.join("$BUILD_DIR", "FrameworkCMSISVariant"),
+    package_dir,
+    sources
+)

--- a/builder/frameworks/atmelstart.py
+++ b/builder/frameworks/atmelstart.py
@@ -33,7 +33,7 @@ env = DefaultEnvironment()
 env.SConscript("_bare.py")
 
 output_filename = os.path.join(env.subst('$PROJECTBUILD_DIR'), "output.json")
-DOWNLOAD_DIR = os.path.join(env.subst('PROJECTWORKSPACE_DIR'), ".downloads")
+DOWNLOAD_DIR = os.path.join(env.subst('$PROJECTWORKSPACE_DIR'), ".downloads")
 PACKAGES_DIR = os.path.join(env.subst('$PROJECTBUILD_DIR'), "packages")
 
 config = configparser.ConfigParser()

--- a/examples/atmelstart-blink/platformio.ini
+++ b/examples/atmelstart-blink/platformio.ini
@@ -1,0 +1,15 @@
+[env:AdafruitFeatherM0]
+platform = atmelsam
+board = adafruit_feather_m0
+framework = atmelstart
+atstart_file = AdafruitFeatherM0.atstart
+build_flags =
+  -D FAST_CLOCK=47972352
+  -D SLOW_CLOCK=32768
+  -D CONF_CPU_FREQUENCY=FAST_CLOCK
+  -D CONF_GCLK_SERCOM0_CORE_FREQUENCY=FAST_CLOCK
+  -D CONF_GCLK_SERCOM0_SLOW_FREQUENCY=SLOW_CLOCK
+  -Wl,-Map=AdafruitFeatherM0.map
+  -O3
+lib_deps =
+  ; https://github.com/frankleonrose/AtmelStart_PlatformIO

--- a/examples/atmelstart-blink/src/AdafruitFeatherM0.atstart
+++ b/examples/atmelstart-blink/src/AdafruitFeatherM0.atstart
@@ -1,0 +1,556 @@
+format_version: '2'
+name: AdafruitFeatherM0_framework
+versions:
+  api: '1.0'
+  backend: 1.6.148
+  commit: 605f106ab95776472e3febf2fac2471441fb1816
+  content: 1.0.1635
+  content_pack_name: acme-packs-all
+  format: '2'
+  frontend: 1.6.1884
+board:
+  identifier: CustomBoard
+  device: SAMD21G18A-MF
+details: null
+application: null
+middlewares:
+  SLEEP_MANAGER_0:
+    user_label: SLEEP_MANAGER_0
+    configuration: {}
+    definition: Atmel:Sleep_Manager:0.0.1::Sleep_manager
+    functionality: Sleep_Manager
+    api: Sleep-Manager:Sleep-Manager:API
+    dependencies: {}
+drivers:
+  GCLK:
+    user_label: GCLK
+    definition: Atmel:SAMD21_Drivers:0.0.1::SAMD21G18A-MF::GCLK::driver_config_definition::GCLK::HAL:HPL:GCLK
+    functionality: System
+    api: HAL:HPL:GCLK
+    configuration:
+      enable_gclk_gen_0: true
+      enable_gclk_gen_1: false
+      enable_gclk_gen_2: false
+      enable_gclk_gen_3: true
+      enable_gclk_gen_4: false
+      enable_gclk_gen_5: false
+      enable_gclk_gen_6: false
+      enable_gclk_gen_7: false
+      gclk_arch_gen_0_RUNSTDBY: true
+      gclk_arch_gen_0_enable: true
+      gclk_arch_gen_0_idc: false
+      gclk_arch_gen_0_oe: false
+      gclk_arch_gen_0_oov: false
+      gclk_arch_gen_1_RUNSTDBY: false
+      gclk_arch_gen_1_enable: false
+      gclk_arch_gen_1_idc: false
+      gclk_arch_gen_1_oe: false
+      gclk_arch_gen_1_oov: false
+      gclk_arch_gen_2_RUNSTDBY: false
+      gclk_arch_gen_2_enable: false
+      gclk_arch_gen_2_idc: false
+      gclk_arch_gen_2_oe: false
+      gclk_arch_gen_2_oov: false
+      gclk_arch_gen_3_RUNSTDBY: true
+      gclk_arch_gen_3_enable: true
+      gclk_arch_gen_3_idc: false
+      gclk_arch_gen_3_oe: false
+      gclk_arch_gen_3_oov: false
+      gclk_arch_gen_4_RUNSTDBY: false
+      gclk_arch_gen_4_enable: false
+      gclk_arch_gen_4_idc: false
+      gclk_arch_gen_4_oe: false
+      gclk_arch_gen_4_oov: false
+      gclk_arch_gen_5_RUNSTDBY: false
+      gclk_arch_gen_5_enable: false
+      gclk_arch_gen_5_idc: false
+      gclk_arch_gen_5_oe: false
+      gclk_arch_gen_5_oov: false
+      gclk_arch_gen_6_RUNSTDBY: false
+      gclk_arch_gen_6_enable: false
+      gclk_arch_gen_6_idc: false
+      gclk_arch_gen_6_oe: false
+      gclk_arch_gen_6_oov: false
+      gclk_arch_gen_7_RUNSTDBY: false
+      gclk_arch_gen_7_enable: false
+      gclk_arch_gen_7_idc: false
+      gclk_arch_gen_7_oe: false
+      gclk_arch_gen_7_oov: false
+      gclk_gen_0_div: 1
+      gclk_gen_0_div_sel: false
+      gclk_gen_0_oscillator: Digital Frequency Locked Loop (DFLL48M)
+      gclk_gen_1_div: 1
+      gclk_gen_1_div_sel: false
+      gclk_gen_1_oscillator: 32kHz Ultra Low Power Internal Oscillator (OSCULP32K)
+      gclk_gen_2_div: 1
+      gclk_gen_2_div_sel: false
+      gclk_gen_2_oscillator: External Crystal Oscillator 0.4-32MHz (XOSC)
+      gclk_gen_3_div: 1
+      gclk_gen_3_div_sel: false
+      gclk_gen_3_oscillator: 32kHz External Crystal Oscillator (XOSC32K)
+      gclk_gen_4_div: 1
+      gclk_gen_4_div_sel: false
+      gclk_gen_4_oscillator: External Crystal Oscillator 0.4-32MHz (XOSC)
+      gclk_gen_5_div: 1
+      gclk_gen_5_div_sel: false
+      gclk_gen_5_oscillator: External Crystal Oscillator 0.4-32MHz (XOSC)
+      gclk_gen_6_div: 1
+      gclk_gen_6_div_sel: false
+      gclk_gen_6_oscillator: External Crystal Oscillator 0.4-32MHz (XOSC)
+      gclk_gen_7_div: 1
+      gclk_gen_7_div_sel: false
+      gclk_gen_7_oscillator: External Crystal Oscillator 0.4-32MHz (XOSC)
+    optional_signals: []
+    variant: null
+    clocks:
+      domain_group: null
+  PM:
+    user_label: PM
+    definition: Atmel:SAMD21_Drivers:0.0.1::SAMD21G18A-MF::PM::driver_config_definition::PM::HAL:HPL:PM
+    functionality: System
+    api: HAL:HPL:PM
+    configuration:
+      apba_div: '1'
+      apbb_div: '1'
+      apbc_div: '1'
+      cpu_clock_source: Generic clock generator 0
+      cpu_div: '1'
+      enable_cpu_clock: true
+      nvm_wait_states: '1'
+    optional_signals: []
+    variant: null
+    clocks:
+      domain_group:
+        nodes:
+        - name: CPU
+          input: CPU
+          external: false
+          external_frequency: 0
+        configuration: {}
+  USART_0:
+    user_label: USART_0
+    definition: Atmel:SAMD21_Drivers:0.0.1::SAMD21G18A-MF::SERCOM0::driver_config_definition::UART::HAL:Driver:USART.Sync
+    functionality: USART
+    api: HAL:Driver:USART_Sync
+    configuration:
+      usart_advanced: false
+      usart_arch_clock_mode: USART with internal clock
+      usart_arch_cloden: false
+      usart_arch_dbgstop: Keep running
+      usart_arch_dord: LSB is transmitted first
+      usart_arch_enc: No encoding
+      usart_arch_fractional: 0
+      usart_arch_ibon: false
+      usart_arch_lin_slave_enable: Disable
+      usart_arch_runstdby: false
+      usart_arch_sampa: 7-8-9 (3-4-5 8-bit over-sampling)
+      usart_arch_sampr: 16x arithmetic
+      usart_arch_sfde: false
+      usart_baud_rate: 9600
+      usart_character_size: 8 bits
+      usart_parity: No parity
+      usart_rx_enable: true
+      usart_stop_bit: One stop bit
+      usart_tx_enable: true
+    optional_signals: []
+    variant:
+      specification: TXPO=1, RXPO=3, CMODE=0
+      required_signals:
+      - name: SERCOM0/PAD/2
+        pad: PA10
+        label: TX
+      - name: SERCOM0/PAD/3
+        pad: PA11
+        label: RX
+    clocks:
+      domain_group:
+        nodes:
+        - name: Core
+          input: Generic clock generator 0
+          external: false
+          external_frequency: 0
+        - name: Slow
+          input: Generic clock generator 3
+          external: false
+          external_frequency: 0
+        configuration:
+          core_gclk_selection: Generic clock generator 0
+          slow_gclk_selection: Generic clock generator 3
+  DMAC:
+    user_label: DMAC
+    definition: Atmel:SAMD21_Drivers:0.0.1::SAMD21G18A-MF::DMAC::driver_config_definition::DMAC::HAL:HPL:DMAC
+    functionality: System
+    api: HAL:HPL:DMAC
+    configuration:
+      dmac_beatsize_0: 8-bit bus transfer
+      dmac_beatsize_1: 8-bit bus transfer
+      dmac_beatsize_10: 8-bit bus transfer
+      dmac_beatsize_11: 8-bit bus transfer
+      dmac_beatsize_12: 8-bit bus transfer
+      dmac_beatsize_13: 8-bit bus transfer
+      dmac_beatsize_14: 8-bit bus transfer
+      dmac_beatsize_15: 8-bit bus transfer
+      dmac_beatsize_2: 8-bit bus transfer
+      dmac_beatsize_3: 8-bit bus transfer
+      dmac_beatsize_4: 8-bit bus transfer
+      dmac_beatsize_5: 8-bit bus transfer
+      dmac_beatsize_6: 8-bit bus transfer
+      dmac_beatsize_7: 8-bit bus transfer
+      dmac_beatsize_8: 8-bit bus transfer
+      dmac_beatsize_9: 8-bit bus transfer
+      dmac_blockact_0: Channel will be disabled if it is the last block transfer in
+        the transaction
+      dmac_blockact_1: Channel will be disabled if it is the last block transfer in
+        the transaction
+      dmac_blockact_10: Channel will be disabled if it is the last block transfer
+        in the transaction
+      dmac_blockact_11: Channel will be disabled if it is the last block transfer
+        in the transaction
+      dmac_blockact_12: Channel will be disabled if it is the last block transfer
+        in the transaction
+      dmac_blockact_13: Channel will be disabled if it is the last block transfer
+        in the transaction
+      dmac_blockact_14: Channel will be disabled if it is the last block transfer
+        in the transaction
+      dmac_blockact_15: Channel will be disabled if it is the last block transfer
+        in the transaction
+      dmac_blockact_2: Channel will be disabled if it is the last block transfer in
+        the transaction
+      dmac_blockact_3: Channel will be disabled if it is the last block transfer in
+        the transaction
+      dmac_blockact_4: Channel will be disabled if it is the last block transfer in
+        the transaction
+      dmac_blockact_5: Channel will be disabled if it is the last block transfer in
+        the transaction
+      dmac_blockact_6: Channel will be disabled if it is the last block transfer in
+        the transaction
+      dmac_blockact_7: Channel will be disabled if it is the last block transfer in
+        the transaction
+      dmac_blockact_8: Channel will be disabled if it is the last block transfer in
+        the transaction
+      dmac_blockact_9: Channel will be disabled if it is the last block transfer in
+        the transaction
+      dmac_channel_0_settings: false
+      dmac_channel_10_settings: false
+      dmac_channel_11_settings: false
+      dmac_channel_12_settings: false
+      dmac_channel_13_settings: false
+      dmac_channel_14_settings: false
+      dmac_channel_15_settings: false
+      dmac_channel_1_settings: false
+      dmac_channel_2_settings: false
+      dmac_channel_3_settings: false
+      dmac_channel_4_settings: false
+      dmac_channel_5_settings: false
+      dmac_channel_6_settings: false
+      dmac_channel_7_settings: false
+      dmac_channel_8_settings: false
+      dmac_channel_9_settings: false
+      dmac_dbgrun: false
+      dmac_dstinc_0: false
+      dmac_dstinc_1: false
+      dmac_dstinc_10: false
+      dmac_dstinc_11: false
+      dmac_dstinc_12: false
+      dmac_dstinc_13: false
+      dmac_dstinc_14: false
+      dmac_dstinc_15: false
+      dmac_dstinc_2: false
+      dmac_dstinc_3: false
+      dmac_dstinc_4: false
+      dmac_dstinc_5: false
+      dmac_dstinc_6: false
+      dmac_dstinc_7: false
+      dmac_dstinc_8: false
+      dmac_dstinc_9: false
+      dmac_enable: false
+      dmac_enable_0: false
+      dmac_enable_1: false
+      dmac_enable_10: false
+      dmac_enable_11: false
+      dmac_enable_12: false
+      dmac_enable_13: false
+      dmac_enable_14: false
+      dmac_enable_15: false
+      dmac_enable_2: false
+      dmac_enable_3: false
+      dmac_enable_4: false
+      dmac_enable_5: false
+      dmac_enable_6: false
+      dmac_enable_7: false
+      dmac_enable_8: false
+      dmac_enable_9: false
+      dmac_evact_0: No action
+      dmac_evact_1: No action
+      dmac_evact_10: No action
+      dmac_evact_11: No action
+      dmac_evact_12: No action
+      dmac_evact_13: No action
+      dmac_evact_14: No action
+      dmac_evact_15: No action
+      dmac_evact_2: No action
+      dmac_evact_3: No action
+      dmac_evact_4: No action
+      dmac_evact_5: No action
+      dmac_evact_6: No action
+      dmac_evact_7: No action
+      dmac_evact_8: No action
+      dmac_evact_9: No action
+      dmac_evie_0: false
+      dmac_evie_1: false
+      dmac_evie_10: false
+      dmac_evie_11: false
+      dmac_evie_12: false
+      dmac_evie_13: false
+      dmac_evie_14: false
+      dmac_evie_15: false
+      dmac_evie_2: false
+      dmac_evie_3: false
+      dmac_evie_4: false
+      dmac_evie_5: false
+      dmac_evie_6: false
+      dmac_evie_7: false
+      dmac_evie_8: false
+      dmac_evie_9: false
+      dmac_evoe_0: false
+      dmac_evoe_1: false
+      dmac_evoe_10: false
+      dmac_evoe_11: false
+      dmac_evoe_12: false
+      dmac_evoe_13: false
+      dmac_evoe_14: false
+      dmac_evoe_15: false
+      dmac_evoe_2: false
+      dmac_evoe_3: false
+      dmac_evoe_4: false
+      dmac_evoe_5: false
+      dmac_evoe_6: false
+      dmac_evoe_7: false
+      dmac_evoe_8: false
+      dmac_evoe_9: false
+      dmac_evosel_0: Event generation disabled
+      dmac_evosel_1: Event generation disabled
+      dmac_evosel_10: Event generation disabled
+      dmac_evosel_11: Event generation disabled
+      dmac_evosel_12: Event generation disabled
+      dmac_evosel_13: Event generation disabled
+      dmac_evosel_14: Event generation disabled
+      dmac_evosel_15: Event generation disabled
+      dmac_evosel_2: Event generation disabled
+      dmac_evosel_3: Event generation disabled
+      dmac_evosel_4: Event generation disabled
+      dmac_evosel_5: Event generation disabled
+      dmac_evosel_6: Event generation disabled
+      dmac_evosel_7: Event generation disabled
+      dmac_evosel_8: Event generation disabled
+      dmac_evosel_9: Event generation disabled
+      dmac_lvl_0: Channel priority 0
+      dmac_lvl_1: Channel priority 0
+      dmac_lvl_10: Channel priority 0
+      dmac_lvl_11: Channel priority 0
+      dmac_lvl_12: Channel priority 0
+      dmac_lvl_13: Channel priority 0
+      dmac_lvl_14: Channel priority 0
+      dmac_lvl_15: Channel priority 0
+      dmac_lvl_2: Channel priority 0
+      dmac_lvl_3: Channel priority 0
+      dmac_lvl_4: Channel priority 0
+      dmac_lvl_5: Channel priority 0
+      dmac_lvl_6: Channel priority 0
+      dmac_lvl_7: Channel priority 0
+      dmac_lvl_8: Channel priority 0
+      dmac_lvl_9: Channel priority 0
+      dmac_lvlen0: false
+      dmac_lvlen1: false
+      dmac_lvlen2: false
+      dmac_lvlen3: false
+      dmac_lvlpri0: 0
+      dmac_lvlpri1: 0
+      dmac_lvlpri2: 0
+      dmac_lvlpri3: 0
+      dmac_rrlvlen0: Static arbitration scheme for channel with priority 0
+      dmac_rrlvlen1: Static arbitration scheme for channel with priority 1
+      dmac_rrlvlen2: Static arbitration scheme for channel with priority 2
+      dmac_rrlvlen3: Static arbitration scheme for channel with priority 3
+      dmac_srcinc_0: false
+      dmac_srcinc_1: false
+      dmac_srcinc_10: false
+      dmac_srcinc_11: false
+      dmac_srcinc_12: false
+      dmac_srcinc_13: false
+      dmac_srcinc_14: false
+      dmac_srcinc_15: false
+      dmac_srcinc_2: false
+      dmac_srcinc_3: false
+      dmac_srcinc_4: false
+      dmac_srcinc_5: false
+      dmac_srcinc_6: false
+      dmac_srcinc_7: false
+      dmac_srcinc_8: false
+      dmac_srcinc_9: false
+      dmac_stepsel_0: Step size settings apply to the destination address
+      dmac_stepsel_1: Step size settings apply to the destination address
+      dmac_stepsel_10: Step size settings apply to the destination address
+      dmac_stepsel_11: Step size settings apply to the destination address
+      dmac_stepsel_12: Step size settings apply to the destination address
+      dmac_stepsel_13: Step size settings apply to the destination address
+      dmac_stepsel_14: Step size settings apply to the destination address
+      dmac_stepsel_15: Step size settings apply to the destination address
+      dmac_stepsel_2: Step size settings apply to the destination address
+      dmac_stepsel_3: Step size settings apply to the destination address
+      dmac_stepsel_4: Step size settings apply to the destination address
+      dmac_stepsel_5: Step size settings apply to the destination address
+      dmac_stepsel_6: Step size settings apply to the destination address
+      dmac_stepsel_7: Step size settings apply to the destination address
+      dmac_stepsel_8: Step size settings apply to the destination address
+      dmac_stepsel_9: Step size settings apply to the destination address
+      dmac_stepsize_0: Next ADDR = ADDR + (BEATSIZE + 1) * 1
+      dmac_stepsize_1: Next ADDR = ADDR + (BEATSIZE + 1) * 1
+      dmac_stepsize_10: Next ADDR = ADDR + (BEATSIZE + 1) * 1
+      dmac_stepsize_11: Next ADDR = ADDR + (BEATSIZE + 1) * 1
+      dmac_stepsize_12: Next ADDR = ADDR + (BEATSIZE + 1) * 1
+      dmac_stepsize_13: Next ADDR = ADDR + (BEATSIZE + 1) * 1
+      dmac_stepsize_14: Next ADDR = ADDR + (BEATSIZE + 1) * 1
+      dmac_stepsize_15: Next ADDR = ADDR + (BEATSIZE + 1) * 1
+      dmac_stepsize_2: Next ADDR = ADDR + (BEATSIZE + 1) * 1
+      dmac_stepsize_3: Next ADDR = ADDR + (BEATSIZE + 1) * 1
+      dmac_stepsize_4: Next ADDR = ADDR + (BEATSIZE + 1) * 1
+      dmac_stepsize_5: Next ADDR = ADDR + (BEATSIZE + 1) * 1
+      dmac_stepsize_6: Next ADDR = ADDR + (BEATSIZE + 1) * 1
+      dmac_stepsize_7: Next ADDR = ADDR + (BEATSIZE + 1) * 1
+      dmac_stepsize_8: Next ADDR = ADDR + (BEATSIZE + 1) * 1
+      dmac_stepsize_9: Next ADDR = ADDR + (BEATSIZE + 1) * 1
+      dmac_trifsrc_0: Only software/event triggers
+      dmac_trifsrc_1: Only software/event triggers
+      dmac_trifsrc_10: Only software/event triggers
+      dmac_trifsrc_11: Only software/event triggers
+      dmac_trifsrc_12: Only software/event triggers
+      dmac_trifsrc_13: Only software/event triggers
+      dmac_trifsrc_14: Only software/event triggers
+      dmac_trifsrc_15: Only software/event triggers
+      dmac_trifsrc_2: Only software/event triggers
+      dmac_trifsrc_3: Only software/event triggers
+      dmac_trifsrc_4: Only software/event triggers
+      dmac_trifsrc_5: Only software/event triggers
+      dmac_trifsrc_6: Only software/event triggers
+      dmac_trifsrc_7: Only software/event triggers
+      dmac_trifsrc_8: Only software/event triggers
+      dmac_trifsrc_9: Only software/event triggers
+      dmac_trigact_0: One trigger required for each block transfer
+      dmac_trigact_1: One trigger required for each block transfer
+      dmac_trigact_10: One trigger required for each block transfer
+      dmac_trigact_11: One trigger required for each block transfer
+      dmac_trigact_12: One trigger required for each block transfer
+      dmac_trigact_13: One trigger required for each block transfer
+      dmac_trigact_14: One trigger required for each block transfer
+      dmac_trigact_15: One trigger required for each block transfer
+      dmac_trigact_2: One trigger required for each block transfer
+      dmac_trigact_3: One trigger required for each block transfer
+      dmac_trigact_4: One trigger required for each block transfer
+      dmac_trigact_5: One trigger required for each block transfer
+      dmac_trigact_6: One trigger required for each block transfer
+      dmac_trigact_7: One trigger required for each block transfer
+      dmac_trigact_8: One trigger required for each block transfer
+      dmac_trigact_9: One trigger required for each block transfer
+    optional_signals: []
+    variant: null
+    clocks:
+      domain_group: null
+  SYSCTRL:
+    user_label: SYSCTRL
+    definition: Atmel:SAMD21_Drivers:0.0.1::SAMD21G18A-MF::SYSCTRL::driver_config_definition::SYSCTRL::HAL:HPL:SYSCTRL
+    functionality: System
+    api: HAL:HPL:SYSCTRL
+    configuration:
+      dfll48m_arch_bplckc: false
+      dfll48m_arch_calibration: false
+      dfll48m_arch_ccdis: false
+      dfll48m_arch_coarse: 31
+      dfll48m_arch_enable: true
+      dfll48m_arch_fine: 512
+      dfll48m_arch_llaw: false
+      dfll48m_arch_ondemand: true
+      dfll48m_arch_qldis: false
+      dfll48m_arch_runstdby: true
+      dfll48m_arch_stable: false
+      dfll48m_arch_usbcrm: false
+      dfll48m_arch_waitlock: true
+      dfll48m_mode: Closed Loop Mode
+      dfll48m_mul: 1463
+      dfll48m_ref_clock: Generic clock generator 3
+      dfll_arch_cstep: 1
+      dfll_arch_fstep: 1
+      enable_dfll48m: true
+      enable_fdpll96m: false
+      enable_osc32k: false
+      enable_osc8m: false
+      enable_osculp32k: false
+      enable_xosc: false
+      enable_xosc32k: true
+      fdpll96m_arch_enable: false
+      fdpll96m_arch_lbypass: false
+      fdpll96m_arch_ondemand: true
+      fdpll96m_arch_runstdby: false
+      fdpll96m_clock_div: 0
+      fdpll96m_ldr: 1463
+      fdpll96m_ldrfrac: 13
+      fdpll96m_ref_clock: Generic clock generator 3
+      osc32k_arch_calib: 0
+      osc32k_arch_en1k: false
+      osc32k_arch_en32k: false
+      osc32k_arch_enable: false
+      osc32k_arch_ondemand: true
+      osc32k_arch_overwrite_calibration: false
+      osc32k_arch_runstdby: false
+      osc32k_arch_startup: 3 Clock Cycles (92us)
+      osc32k_arch_wrtlock: false
+      osc8m_arch_calib: 0
+      osc8m_arch_enable: false
+      osc8m_arch_ondemand: true
+      osc8m_arch_overwrite_calibration: false
+      osc8m_arch_runstdby: false
+      osc8m_presc: '8'
+      osculp32k_arch_calib: 0
+      osculp32k_arch_overwrite_calibration: false
+      osculp32k_arch_wrtlock: false
+      xosc32k_arch_aampen: true
+      xosc32k_arch_en1k: false
+      xosc32k_arch_en32k: true
+      xosc32k_arch_enable: true
+      xosc32k_arch_ondemand: true
+      xosc32k_arch_runstdby: true
+      xosc32k_arch_startup: 1125092 us
+      xosc32k_arch_wrtlock: false
+      xosc32k_arch_xtalen: true
+      xosc_arch_ampgc: false
+      xosc_arch_enable: false
+      xosc_arch_gain: 2Mhz
+      xosc_arch_ondemand: true
+      xosc_arch_runstdby: false
+      xosc_arch_startup: 31 us
+      xosc_arch_xtalen: false
+      xosc_frequency: 400000
+    optional_signals: []
+    variant: null
+    clocks:
+      domain_group: null
+pads:
+  USART_TX_PIN:
+    name: PA10
+    definition: Atmel:SAMD21_Drivers:0.0.1::SAMD21G18A-MF::pad::PA10
+    mode: Peripheral IO
+    user_label: USART_TX_PIN
+    configuration: null
+  USART_RX_PIN:
+    name: PA11
+    definition: Atmel:SAMD21_Drivers:0.0.1::SAMD21G18A-MF::pad::PA11
+    mode: Peripheral IO
+    user_label: USART_RX_PIN
+    configuration: null
+  LED_PIN:
+    name: PA17
+    definition: Atmel:SAMD21_Drivers:0.0.1::SAMD21G18A-MF::pad::PA17
+    mode: Digital output
+    user_label: LED_PIN
+    configuration: null
+toolchain_options: []

--- a/examples/atmelstart-blink/src/main.cpp
+++ b/examples/atmelstart-blink/src/main.cpp
@@ -1,0 +1,15 @@
+#include <atmel_start.h>
+
+int main(void)
+{
+	atmel_start_init(); // Initializes MCU, drivers and middleware
+
+  gpio_set_pin_direction(LED_PIN, GPIO_DIRECTION_OUT);
+  gpio_set_pin_pull_mode(LED_PIN, GPIO_PULL_OFF);
+	gpio_set_pin_level(LED_PIN, false);
+
+  for( ;; ) {
+  	gpio_toggle_pin_level(LED_PIN);
+    delay_ms(500);
+  }
+}

--- a/platform.json
+++ b/platform.json
@@ -23,6 +23,9 @@
       "package": "framework-arduinosam",
       "script": "builder/frameworks/arduino.py"
     },
+    "atmelstart": {
+      "script": "builder/frameworks/atmelstart.py"
+    },
     "mbed": {
       "package": "framework-mbed",
       "script": "builder/frameworks/mbed/mbed.py"


### PR DESCRIPTION
As discussed in #33, here's my proposed Atmel Start builder.

Current issues (can be seen building examples/atmelstart-blink):

- PlatformIO issues a warning about the use of `atstart_file` option. Is there a way to silence that warning?
> Warning! Ignore unknown configuration option `atstart_file` in section [env:AdafruitFeatherM0]

- The generated file peripheral_clk_config.h sets all clock frequencies to 0. This necessitates including `build_flags` as shown below. I plan to inject `#pragma warning` statements into the peripheral_clk_config.h so that users of the framework are warned when they have not successfully overridden frequency values.
```
build_flags =
  -D CONF_CPU_FREQUENCY=47972352
  -D CONF_GCLK_SERCOM0_CORE_FREQUENCY=47972352
  -D CONF_GCLK_SERCOM0_SLOW_FREQUENCY=32768
```