### PR TITLE
Arduino MKRWAN 1310 Board added

### DIFF
--- a/boards/mkrwan1310.json
+++ b/boards/mkrwan1310.json
@@ -1,0 +1,51 @@
+{
+  "build": {
+    "core": "samd",
+    "cpu": "cortex-m0plus",
+    "extra_flags": "-DARDUINO_SAMD_MKRWAN1300 -DARDUINO_ARCH_SAMD -D__SAMD21G18A__ -DUSE_ARDUINO_MKR_PIN_LAYOUT -DUSE_BQ24195L_PMIC -DVERY_LOW_POWER",
+    "f_cpu": "48000000L",
+    "hwids": [
+      [
+        "0x2341",
+        "0x8059"
+      ],
+      [
+        "0x2341",
+        "0x0059"
+      ]
+    ],
+    "ldscript": "flash_with_bootloader.ld",
+    "mcu": "samd21g18a",
+    "usb_product": "Arduino MKR WAN 1310",
+    "variant": "mkrwan1300"
+  },
+  "debug": {
+    "jlink_device": "ATSAMD21G18",
+    "openocd_chipname": "at91samd21g18",
+    "openocd_target": "at91samdXX",
+    "svd_path": "ATSAMD21G18A.svd"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "Arduino MKR WAN 1310",
+  "upload": {
+    "disable_flushing": true,
+    "maximum_ram_size": 32768,
+    "maximum_size": 262144,
+    "native_usb": true,
+    "offset_address": "0x2000",
+    "protocol": "sam-ba",
+    "protocols": [
+      "sam-ba",
+      "blackmagic",
+      "jlink",
+      "atmel-ice"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true
+  },
+  "url": "https://store.arduino.cc/mkr-wan-1310",
+  "vendor": "Arduino"
+}


### PR DESCRIPTION
This adds the new Arduino Board, [MKR WAN 1310](https://store.arduino.cc/mkr-wan-1310).

I tested everything (build, upload) and it works fine for me (using a CLion dev environment with the latest PlatformIO toolchain).

Resolves https://github.com/platformio/platform-atmelsam/issues/86