### PR TITLE
Changed the checking for sam or samd in platform.py to be consistant with arduino.py and arduino-common.py

### DIFF
--- a/platform.py
+++ b/platform.py
@@ -51,7 +51,7 @@ class AtmelsamPlatform(PlatformBase):
 
         if "arduino" in variables.get("pioframework", []):
             framework_package = "framework-arduino-%s" % (
-                "samd" if board.get("build.mcu", "").startswith("samd") else "sam")
+                "sam" if board.get("build.mcu", "").startswith("at91") else "samd")
 
             if build_core != "arduino":
                 framework_package += "-" + build_core


### PR DESCRIPTION
There are three places where it decides between the sam or samd packages.  Two of them checked to see if the mcu started with "at91" and if so it was the sam, otherwise it was the samd.  The third one (the one in platform.py) checked to see if the mcu started with "samd" and if so it was the samd, otherwise it was the sam.  This causes problems with the samc and saml which both are essentially the samd core and use the samd packages.