### PR TITLE
added ARDUINO_ARCH_SAMD build flag for WioTerminal

### DIFF
--- a/boards/seeed_wio_terminal.json
+++ b/boards/seeed_wio_terminal.json
@@ -6,6 +6,7 @@
     "core": "seeed",
     "cpu": "cortex-m4",
     "extra_flags": [
+      "-DARDUINO_ARCH_SAMD",
       "-D__SAMD51P19A__",
       "-DWIO_TERMINAL",
       "-DSEEED_WIO_TERMINAL",


### PR DESCRIPTION
Without this, the following compilation errors will occur.

`.platformio/packages/framework-arduino-samd-seeed/libraries/Seeed_Arduino_LCD/User_Setup.h:157:6: error: #error "you need to config in USer_Setup.h"`