### PR TITLE
Add support for programming the SAM3X on the Udoo Quad

### DIFF
--- a/boards/udoo_quad.json
+++ b/boards/udoo_quad.json
@@ -1,0 +1,49 @@
+{
+  "build": {
+    "arduino": {
+        "ldscript": "flash.ld"
+    },
+    "core": "arduino",
+    "cpu": "cortex-m3",
+    "extra_flags": "-D__SAM3X8E__ -DARDUINO_SAM_DUE",
+    "f_cpu": "84000000L",
+    "hwids": [
+      [
+        "0x10C4",
+        "0xEA60"
+      ]
+    ],
+    "mcu": "at91sam3x8e",
+    "usb_product": "Arduino Due",
+    "variant": "arduino_due_x"
+  },
+  "connectivity": [
+    "can"
+  ],
+  "debug": {
+    "jlink_device": "ATSAM3X8E",
+    "openocd_chipname": "at91sam3X8E",
+    "openocd_target": "at91sam3ax_8x",
+    "svd_path": "ATSAM3X8E.svd"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "Udoo Quad",
+  "upload": {
+    "disable_flushing": true,
+    "maximum_ram_size": 98304,
+    "maximum_size": 524288,
+    "native_usb": false,
+    "protocol": "sam-ba",
+    "protocols": [
+      "sam-ba"
+    ],
+    "internal": false,
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.udoo.org/",
+  "vendor": "Udoo"
+}

--- a/boards/udoo_quad_internal.json
+++ b/boards/udoo_quad_internal.json
@@ -1,0 +1,49 @@
+{
+  "build": {
+    "arduino": {
+        "ldscript": "flash.ld"
+    },
+    "core": "arduino",
+    "cpu": "cortex-m3",
+    "extra_flags": "-D__SAM3X8E__ -DARDUINO_SAM_DUE",
+    "f_cpu": "84000000L",
+    "hwids": [
+      [
+        "0x10C4",
+        "0xEA60"
+      ]
+    ],
+    "mcu": "at91sam3x8e",
+    "usb_product": "Arduino Due",
+    "variant": "arduino_due_x"
+  },
+  "connectivity": [
+    "can"
+  ],
+  "debug": {
+    "jlink_device": "ATSAM3X8E",
+    "openocd_chipname": "at91sam3X8E",
+    "openocd_target": "at91sam3ax_8x",
+    "svd_path": "ATSAM3X8E.svd"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "Udoo Quad",
+  "upload": {
+    "disable_flushing": true,
+    "maximum_ram_size": 98304,
+    "maximum_size": 524288,
+    "native_usb": false,
+    "protocol": "sam-ba",
+    "protocols": [
+      "sam-ba"
+    ],
+    "internal": true,
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.udoo.org/",
+  "vendor": "Udoo"
+}

--- a/builder/main.py
+++ b/builder/main.py
@@ -214,6 +214,13 @@ elif upload_protocol == "sam-ba":
         ],
         UPLOADCMD="$UPLOADER $UPLOADERFLAGS $SOURCES"
     )
+
+    # use patched bossac for Udoo Quad
+    if board.get("name") in ("Udoo Quad", "Udoo Dual"):
+        if bool(board.get("upload.internal", False)):
+            env.Replace(UPLOADER="bossac-udoo-internal")
+        env.Replace(UPLOADER="bossac-udoo")
+
     if board.get("build.core") in ("adafruit", "seeed") and board.get(
             "build.mcu").startswith("samd51"):
         # special flags for the latest bossac tool
@@ -267,9 +274,9 @@ elif upload_protocol == "mbctool":
             "--device", "samd",
             "--speed", "1500000",
             "--port", '"$UPLOAD_PORT"',
-            "--upload", "$SOURCES",            
+            "--upload", "$SOURCES",
         ],
-        UPLOADCMD='"$UPLOADER" $UPLOADERFLAGS'       
+        UPLOADCMD='"$UPLOADER" $UPLOADERFLAGS'
     )
     upload_actions = [
         env.VerboseAction(env.AutodetectUploadPort,

--- a/platform.json
+++ b/platform.json
@@ -15,7 +15,8 @@
   "packageRepositories": [
     "https://dl.bintray.com/platformio/dl-packages/manifest.json",
     "http://dl.platformio.org/packages/manifest.json",
-    "https://raw.githubusercontent.com/eerimoq/simba/master/make/platformio/manifest.json"
+    "https://raw.githubusercontent.com/eerimoq/simba/master/make/platformio/manifest.json",
+    "https://raw.githubusercontent.com/ArkadiuszMichalRys/bossac-udoo/master/platformio/manifest.json"
   ],
   "frameworks": {
     "arduino": {
@@ -200,6 +201,11 @@
       "type": "uploader",
       "optional": true,
       "version": "~1.10700.0"
+    },
+    "tool-bossac-udoo": {
+      "type": "uploader",
+      "optional": true,
+      "version": "~0.0.1"
     },
     "tool-mbctool": {
       "optional": true,

--- a/platform.py
+++ b/platform.py
@@ -31,6 +31,8 @@ class AtmelsamPlatform(PlatformBase):
         upload_tool = "tool-openocd"
         if upload_protocol == "sam-ba":
             upload_tool = "tool-bossac"
+            if board.get("name") in ("Udoo Quad", "Udoo Dual"):
+                upload_tool = "tool-bossac-udoo"
         elif upload_protocol == "stk500v2":
             upload_tool = "tool-avrdude"
         elif upload_protocol == "jlink":


### PR DESCRIPTION
This PR adds support for a new board. The Udoo Quad or Dual. This board can be programmed from an external computer (1) or from the internal processor (2). I have therefore, added two new board configurations.

1. Udoo Quad
2. Udoo Quad Internal

The Udoo Quad needs a modifed bossac as it resets the SAM3X using a custom kernel module on the main processor. This means I also had to add the modified bossac tool in the manifest file.
This new tool is called when one of the Udoo board configurations is used.

This should be a step towards closing platformio/platformio-core#439.
I cannot add support for the Udoo Neo as I do not have access to the hardware to test it.