### PR TITLE
Change JLink CPU to correct name so that debugging works

### DIFF
--- a/boards/adafruit_feather_m4_can.json
+++ b/boards/adafruit_feather_m4_can.json
@@ -33,7 +33,7 @@
     "variant": "feather_m4_can"
   },
   "debug": {
-    "jlink_device": "ATSAMD51J19",
+    "jlink_device": "ATSAME51J19",
     "openocd_chipname": "at91samd51j19",
     "openocd_target": "atsame5x",
     "svd_path": "ATSAMD51J19A.svd"


### PR DESCRIPTION
The CPU on the Feather M4 CAN is the SAME51J19A rather than the SAMD51J19A on the Feather M4 Express. For JLink to debug without issue the correct MCU needs to be selected otherwise debugging appears to work (i.e. will start) but then fails when attempting to step through code.
[I guess there OpenOCD setting should also be changed, but I use JLink so haven't tested]