### PR TITLE
Add ATSAMD21J18A.svd from Microchip.SAMD21_DFP.3.4.116

### DIFF
--- a/misc/svd/ATSAMD21J18A.svd
+++ b/misc/svd/ATSAMD21J18A.svd
@@ -1,0 +1,19484 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device schemaVersion="1.2" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="CMSIS-SVD.xsd">
+  <vendor>Microchip Technology Inc.</vendor>
+  <vendorID>MICROCHIP</vendorID>
+  <name>ATSAMD21J18A</name>
+  <series>SAMD21</series>
+  <version>D</version>
+  <description>Microchip ATSAMD21J18A device: Cortex-M0+ Microcontroller with 256KB Flash, 32KB SRAM, 64-pin package</description>
+  <licenseText>
+  Copyright (c) 2018 Microchip Technology Inc.\n
+\n
+  SPDX-License-Identifier: Apache-2.0\n
+\n
+  Licensed under the Apache License, Version 2.0 (the "License");\n
+  you may not use this file except in compliance with the License.\n
+  You may obtain a copy of the License at\n
+\n
+  http://www.apache.org/licenses/LICENSE-2.0\n
+\n
+  Unless required by applicable law or agreed to in writing, software\n
+  distributed under the License is distributed on an "AS IS" BASIS,\n
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n
+  See the License for the specific language governing permissions and\n
+  limitations under the License.
+  </licenseText>
+  <cpu>
+    <name>CM0+</name>
+    <revision>r0p1</revision>
+    <endian>little</endian>
+    <mpuPresent>false</mpuPresent>
+    <fpuPresent>false</fpuPresent>
+    <vtorPresent>true</vtorPresent>
+    <nvicPrioBits>2</nvicPrioBits>
+    <vendorSystickConfig>false</vendorSystickConfig>
+    <deviceNumInterrupts>28</deviceNumInterrupts>
+  </cpu>
+  <headerSystemFilename>system_samd21</headerSystemFilename>
+  <addressUnitBits>8</addressUnitBits>
+  <width>32</width>
+  <size>32</size>
+  <access>read-write</access>
+  <resetValue>0x00000000</resetValue>
+  <resetMask>0xFFFFFFFF</resetMask>
+  <peripherals>
+    <peripheral>
+      <name>AC</name>
+      <version>1.1.1</version>
+      <description>Analog Comparators</description>
+      <groupName>AC</groupName>
+      <prependToName>AC_</prependToName>
+      <baseAddress>0x42004400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>AC</name>
+        <value>24</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMUX</name>
+              <description>Low-Power Mux</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>Control B</description>
+          <addressOffset>0x01</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>START0</name>
+              <description>Comparator 0 Start Comparison</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>START1</name>
+              <description>Comparator 1 Start Comparison</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>COMPEO0</name>
+              <description>Comparator 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMPEO1</name>
+              <description>Comparator 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINEO0</name>
+              <description>Window 0 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMPEI0</name>
+              <description>Comparator 0 Event Input</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMPEI1</name>
+              <description>Comparator 1 Event Input</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>COMP0</name>
+              <description>Comparator 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMP1</name>
+              <description>Comparator 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WIN0</name>
+              <description>Window 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>COMP0</name>
+              <description>Comparator 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMP1</name>
+              <description>Comparator 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WIN0</name>
+              <description>Window 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>COMP0</name>
+              <description>Comparator 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMP1</name>
+              <description>Comparator 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WIN0</name>
+              <description>Window 0</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSA</name>
+          <description>Status A</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>STATE0</name>
+              <description>Comparator 0 Current State</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STATE1</name>
+              <description>Comparator 1 Current State</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WSTATE0</name>
+              <description>Window 0 Current State</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WSTATE0Select</name>
+                <enumeratedValue>
+                  <name>ABOVE</name>
+                  <description>Signal is above window</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INSIDE</name>
+                  <description>Signal is inside window</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BELOW</name>
+                  <description>Signal is below window</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSB</name>
+          <description>Status B</description>
+          <addressOffset>0x09</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>READY0</name>
+              <description>Comparator 0 Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>READY1</name>
+              <description>Comparator 1 Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSC</name>
+          <description>Status C</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>STATE0</name>
+              <description>Comparator 0 Current State</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STATE1</name>
+              <description>Comparator 1 Current State</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WSTATE0</name>
+              <description>Window 0 Current State</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WSTATE0Select</name>
+                <enumeratedValue>
+                  <name>ABOVE</name>
+                  <description>Signal is above window</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INSIDE</name>
+                  <description>Signal is inside window</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BELOW</name>
+                  <description>Signal is below window</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WINCTRL</name>
+          <description>Window Control</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>WEN0</name>
+              <description>Window 0 Mode Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINTSEL0</name>
+              <description>Window 0 Interrupt Selection</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WINTSEL0Select</name>
+                <enumeratedValue>
+                  <name>ABOVE</name>
+                  <description>Interrupt on signal above window</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INSIDE</name>
+                  <description>Interrupt on signal inside window</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BELOW</name>
+                  <description>Interrupt on signal below window</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OUTSIDE</name>
+                  <description>Interrupt on signal outside window</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>COMPCTRL%s</name>
+          <description>Comparator Control n</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SINGLE</name>
+              <description>Single-Shot Mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPEED</name>
+              <description>Speed Selection</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SPEEDSelect</name>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low speed</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High speed</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>INTSEL</name>
+              <description>Interrupt Selection</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>INTSELSelect</name>
+                <enumeratedValue>
+                  <name>TOGGLE</name>
+                  <description>Interrupt on comparator output toggle</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISING</name>
+                  <description>Interrupt on comparator output rising</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALLING</name>
+                  <description>Interrupt on comparator output falling</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EOC</name>
+                  <description>Interrupt on end of comparison (single-shot mode only)</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MUXNEG</name>
+              <description>Negative Input Mux Selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MUXNEGSelect</name>
+                <enumeratedValue>
+                  <name>PIN0</name>
+                  <description>I/O pin 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN1</name>
+                  <description>I/O pin 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN2</name>
+                  <description>I/O pin 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN3</name>
+                  <description>I/O pin 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GND</name>
+                  <description>Ground</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>VSCALE</name>
+                  <description>VDD scaler</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BANDGAP</name>
+                  <description>Internal bandgap voltage</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DAC</name>
+                  <description>DAC output</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MUXPOS</name>
+              <description>Positive Input Mux Selection</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MUXPOSSelect</name>
+                <enumeratedValue>
+                  <name>PIN0</name>
+                  <description>I/O pin 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN1</name>
+                  <description>I/O pin 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN2</name>
+                  <description>I/O pin 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN3</name>
+                  <description>I/O pin 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SWAP</name>
+              <description>Swap Inputs and Invert</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OUT</name>
+              <description>Output</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>OUTSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>The output of COMPn is not routed to the COMPn I/O port</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ASYNC</name>
+                  <description>The asynchronous output of COMPn is routed to the COMPn I/O port</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYNC</name>
+                  <description>The synchronous output (including filtering) of COMPn is routed to the COMPn I/O port</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>HYST</name>
+              <description>Hysteresis Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FLEN</name>
+              <description>Filter Length</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>FLENSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>No filtering</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MAJ3</name>
+                  <description>3-bit majority function (2 of 3)</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MAJ5</name>
+                  <description>5-bit majority function (3 of 5)</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x1</dimIncrement>
+          <name>SCALER%s</name>
+          <description>Scaler n</description>
+          <addressOffset>0x20</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>VALUE</name>
+              <description>Scaler Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>ADC</name>
+      <version>1.2.0</version>
+      <description>Analog Digital Converter</description>
+      <groupName>ADC</groupName>
+      <prependToName>ADC_</prependToName>
+      <baseAddress>0x42004000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>ADC</name>
+        <value>23</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>REFCTRL</name>
+          <description>Reference Control</description>
+          <addressOffset>0x01</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>REFSEL</name>
+              <description>Reference Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>REFSELSelect</name>
+                <enumeratedValue>
+                  <name>INT1V</name>
+                  <description>1.0V voltage reference</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INTVCC0</name>
+                  <description>1/1.48 VDDANA</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INTVCC1</name>
+                  <description>1/2 VDDANA (only for VDDANA &gt; 2.0V)</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AREFA</name>
+                  <description>External reference</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AREFB</name>
+                  <description>External reference</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>REFCOMP</name>
+              <description>Reference Buffer Offset Compensation Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AVGCTRL</name>
+          <description>Average Control</description>
+          <addressOffset>0x02</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SAMPLENUM</name>
+              <description>Number of Samples to be Collected</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>SAMPLENUMSelect</name>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>1 sample</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>2 samples</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4</name>
+                  <description>4 samples</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 samples</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 samples</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 samples</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 samples</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 samples</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 samples</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 samples</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1024</name>
+                  <description>1024 samples</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADJRES</name>
+              <description>Adjusting Result / Division Coefficient</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SAMPCTRL</name>
+          <description>Sampling Time Control</description>
+          <addressOffset>0x03</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SAMPLEN</name>
+              <description>Sampling Time Length</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>DIFFMODE</name>
+              <description>Differential Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LEFTADJ</name>
+              <description>Left-Adjusted Result</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FREERUN</name>
+              <description>Free Running Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CORREN</name>
+              <description>Digital Correction Logic Enabled</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RESSEL</name>
+              <description>Conversion Result Resolution</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>RESSELSelect</name>
+                <enumeratedValue>
+                  <name>12BIT</name>
+                  <description>12-bit result</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16BIT</name>
+                  <description>For averaging mode output</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>10BIT</name>
+                  <description>10-bit result</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8BIT</name>
+                  <description>8-bit result</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler Configuration</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Peripheral clock divided by 4</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Peripheral clock divided by 8</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Peripheral clock divided by 16</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Peripheral clock divided by 32</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Peripheral clock divided by 64</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Peripheral clock divided by 128</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Peripheral clock divided by 256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>Peripheral clock divided by 512</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WINCTRL</name>
+          <description>Window Monitor Control</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>WINMODE</name>
+              <description>Window Monitor Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>WINMODESelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>No window mode (default)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MODE1</name>
+                  <description>Mode 1: RESULT &gt; WINLT</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MODE2</name>
+                  <description>Mode 2: RESULT &lt; WINUT</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MODE3</name>
+                  <description>Mode 3: WINLT &lt; RESULT &lt; WINUT</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MODE4</name>
+                  <description>Mode 4: !(WINLT &lt; RESULT &lt; WINUT)</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SWTRIG</name>
+          <description>Software Trigger</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>FLUSH</name>
+              <description>ADC Conversion Flush</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>START</name>
+              <description>ADC Start Conversion</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INPUTCTRL</name>
+          <description>Input Control</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>MUXPOS</name>
+              <description>Positive Mux Input Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>MUXPOSSelect</name>
+                <enumeratedValue>
+                  <name>PIN0</name>
+                  <description>ADC AIN0 Pin</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN1</name>
+                  <description>ADC AIN1 Pin</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN2</name>
+                  <description>ADC AIN2 Pin</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN3</name>
+                  <description>ADC AIN3 Pin</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN4</name>
+                  <description>ADC AIN4 Pin</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN5</name>
+                  <description>ADC AIN5 Pin</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN6</name>
+                  <description>ADC AIN6 Pin</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN7</name>
+                  <description>ADC AIN7 Pin</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN8</name>
+                  <description>ADC AIN8 Pin</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN9</name>
+                  <description>ADC AIN9 Pin</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN10</name>
+                  <description>ADC AIN10 Pin</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN11</name>
+                  <description>ADC AIN11 Pin</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN12</name>
+                  <description>ADC AIN12 Pin</description>
+                  <value>0xc</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN13</name>
+                  <description>ADC AIN13 Pin</description>
+                  <value>0xd</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN14</name>
+                  <description>ADC AIN14 Pin</description>
+                  <value>0xe</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN15</name>
+                  <description>ADC AIN15 Pin</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN16</name>
+                  <description>ADC AIN16 Pin</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN17</name>
+                  <description>ADC AIN17 Pin</description>
+                  <value>0x11</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN18</name>
+                  <description>ADC AIN18 Pin</description>
+                  <value>0x12</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN19</name>
+                  <description>ADC AIN19 Pin</description>
+                  <value>0x13</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TEMP</name>
+                  <description>Temperature Reference</description>
+                  <value>0x18</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BANDGAP</name>
+                  <description>Bandgap Voltage</description>
+                  <value>0x19</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SCALEDCOREVCC</name>
+                  <description>1/4  Scaled Core Supply</description>
+                  <value>0x1a</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SCALEDIOVCC</name>
+                  <description>1/4  Scaled I/O Supply</description>
+                  <value>0x1b</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DAC</name>
+                  <description>DAC Output</description>
+                  <value>0x1c</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MUXNEG</name>
+              <description>Negative Mux Input Selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>MUXNEGSelect</name>
+                <enumeratedValue>
+                  <name>PIN0</name>
+                  <description>ADC AIN0 Pin</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN1</name>
+                  <description>ADC AIN1 Pin</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN2</name>
+                  <description>ADC AIN2 Pin</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN3</name>
+                  <description>ADC AIN3 Pin</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN4</name>
+                  <description>ADC AIN4 Pin</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN5</name>
+                  <description>ADC AIN5 Pin</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN6</name>
+                  <description>ADC AIN6 Pin</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN7</name>
+                  <description>ADC AIN7 Pin</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GND</name>
+                  <description>Internal Ground</description>
+                  <value>0x18</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>IOGND</name>
+                  <description>I/O Ground</description>
+                  <value>0x19</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>INPUTSCAN</name>
+              <description>Number of Input Channels Included in Scan</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>INPUTOFFSET</name>
+              <description>Positive Mux Setting Offset</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>GAIN</name>
+              <description>Gain Factor Selection</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>GAINSelect</name>
+                <enumeratedValue>
+                  <name>1X</name>
+                  <description>1x</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2X</name>
+                  <description>2x</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4X</name>
+                  <description>4x</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8X</name>
+                  <description>8x</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16X</name>
+                  <description>16x</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>1/2x</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>STARTEI</name>
+              <description>Start Conversion Event In</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCEI</name>
+              <description>Synchronization Event In</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RESRDYEO</name>
+              <description>Result Ready Event Out</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINMONEO</name>
+              <description>Window Monitor Event Out</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>RESRDY</name>
+              <description>Result Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVERRUN</name>
+              <description>Overrun Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINMON</name>
+              <description>Window Monitor Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x17</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>RESRDY</name>
+              <description>Result Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVERRUN</name>
+              <description>Overrun Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINMON</name>
+              <description>Window Monitor Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>RESRDY</name>
+              <description>Result Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVERRUN</name>
+              <description>Overrun</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINMON</name>
+              <description>Window Monitor</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x19</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RESULT</name>
+          <description>Result</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>RESULT</name>
+              <description>Result Conversion Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WINLT</name>
+          <description>Window Monitor Lower Threshold</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>WINLT</name>
+              <description>Window Lower Threshold</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WINUT</name>
+          <description>Window Monitor Upper Threshold</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>WINUT</name>
+              <description>Window Upper Threshold</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>GAINCORR</name>
+          <description>Gain Correction</description>
+          <addressOffset>0x24</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>GAINCORR</name>
+              <description>Gain Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OFFSETCORR</name>
+          <description>Offset Correction</description>
+          <addressOffset>0x26</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>OFFSETCORR</name>
+              <description>Offset Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CALIB</name>
+          <description>Calibration</description>
+          <addressOffset>0x28</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>LINEARITY_CAL</name>
+              <description>Linearity Calibration Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>BIAS_CAL</name>
+              <description>Bias Calibration Value</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x2A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>DAC</name>
+      <version>1.1.0</version>
+      <description>Digital Analog Converter</description>
+      <groupName>DAC</groupName>
+      <prependToName>DAC_</prependToName>
+      <baseAddress>0x42004800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>DAC</name>
+        <value>25</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x0</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>Control B</description>
+          <addressOffset>0x1</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EOEN</name>
+              <description>External Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IOEN</name>
+              <description>Internal Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LEFTADJ</name>
+              <description>Left Adjusted Data</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>VPD</name>
+              <description>Voltage Pump Disable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BDWP</name>
+              <description>Bypass DATABUF Write Protection</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>REFSEL</name>
+              <description>Reference Selection</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>REFSELSelect</name>
+                <enumeratedValue>
+                  <name>INT1V</name>
+                  <description>Internal 1.0V reference</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AVCC</name>
+                  <description>AVCC</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>VREFP</name>
+                  <description>External reference</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x2</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>STARTEI</name>
+              <description>Start Conversion Event Input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EMPTYEO</name>
+              <description>Data Buffer Empty Event Output</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x4</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>UNDERRUN</name>
+              <description>Underrun Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EMPTY</name>
+              <description>Data Buffer Empty Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x5</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>UNDERRUN</name>
+              <description>Underrun Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EMPTY</name>
+              <description>Data Buffer Empty Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x6</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>UNDERRUN</name>
+              <description>Underrun</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EMPTY</name>
+              <description>Data Buffer Empty</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x7</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy Status</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>Data</description>
+          <addressOffset>0x8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data value to be converted</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATABUF</name>
+          <description>Data Buffer</description>
+          <addressOffset>0xC</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>DATABUF</name>
+              <description>Data Buffer</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>DMAC</name>
+      <version>1.0.0</version>
+      <description>Direct Memory Access Controller</description>
+      <groupName>DMAC</groupName>
+      <prependToName>DMAC_</prependToName>
+      <baseAddress>0x41004800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>DMAC</name>
+        <value>6</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DMAENABLE</name>
+              <description>DMA Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CRCENABLE</name>
+              <description>CRC Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLEN0</name>
+              <description>Priority Level 0 Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLEN1</name>
+              <description>Priority Level 1 Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLEN2</name>
+              <description>Priority Level 2 Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLEN3</name>
+              <description>Priority Level 3 Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CRCCTRL</name>
+          <description>CRC Control</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>CRCBEATSIZE</name>
+              <description>CRC Beat Size</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CRCBEATSIZESelect</name>
+                <enumeratedValue>
+                  <name>BYTE</name>
+                  <description>8-bit bus transfer</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HWORD</name>
+                  <description>16-bit bus transfer</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WORD</name>
+                  <description>32-bit bus transfer</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CRCPOLY</name>
+              <description>CRC Polynomial Type</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CRCPOLYSelect</name>
+                <enumeratedValue>
+                  <name>CRC16</name>
+                  <description>CRC-16 (CRC-CCITT)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CRC32</name>
+                  <description>CRC32 (IEEE 802.3)</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CRCSRC</name>
+              <description>CRC Input Source</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>6</bitWidth>
+              <enumeratedValues>
+                <name>CRCSRCSelect</name>
+                <enumeratedValue>
+                  <name>NOACT</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>IO</name>
+                  <description>I/O interface</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CRCDATAIN</name>
+          <description>CRC Data Input</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CRCDATAIN</name>
+              <description>CRC Data Input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CRCCHKSUM</name>
+          <description>CRC Checksum</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CRCCHKSUM</name>
+              <description>CRC Checksum</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CRCSTATUS</name>
+          <description>CRC Status</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CRCBUSY</name>
+              <description>CRC Module Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CRCZERO</name>
+              <description>CRC Zero</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x0D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>QOSCTRL</name>
+          <description>QOS Control</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <resetValue>0x15</resetValue>
+          <fields>
+            <field>
+              <name>WRBQOS</name>
+              <description>Write-Back Quality of Service</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WRBQOSSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Background (no sensitive operation)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Sensitive Bandwidth</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MEDIUM</name>
+                  <description>Sensitive Latency</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>Critical Latency</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FQOS</name>
+              <description>Fetch Quality of Service</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>FQOSSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Background (no sensitive operation)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Sensitive Bandwidth</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MEDIUM</name>
+                  <description>Sensitive Latency</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>Critical Latency</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>DQOS</name>
+              <description>Data Transfer Quality of Service</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>DQOSSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Background (no sensitive operation)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Sensitive Bandwidth</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MEDIUM</name>
+                  <description>Sensitive Latency</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>Critical Latency</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SWTRIGCTRL</name>
+          <description>Software Trigger Control</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWTRIG0</name>
+              <description>Channel 0 Software Trigger</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG1</name>
+              <description>Channel 1 Software Trigger</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG2</name>
+              <description>Channel 2 Software Trigger</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG3</name>
+              <description>Channel 3 Software Trigger</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG4</name>
+              <description>Channel 4 Software Trigger</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG5</name>
+              <description>Channel 5 Software Trigger</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG6</name>
+              <description>Channel 6 Software Trigger</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG7</name>
+              <description>Channel 7 Software Trigger</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG8</name>
+              <description>Channel 8 Software Trigger</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG9</name>
+              <description>Channel 9 Software Trigger</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG10</name>
+              <description>Channel 10 Software Trigger</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG11</name>
+              <description>Channel 11 Software Trigger</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRICTRL0</name>
+          <description>Priority Control 0</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>LVLPRI0</name>
+              <description>Level 0 Channel Priority Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>RRLVLEN0</name>
+              <description>Level 0 Round-Robin Scheduling Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLPRI1</name>
+              <description>Level 1 Channel Priority Number</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>RRLVLEN1</name>
+              <description>Level 1 Round-Robin Scheduling Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLPRI2</name>
+              <description>Level 2 Channel Priority Number</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>RRLVLEN2</name>
+              <description>Level 2 Round-Robin Scheduling Enable</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLPRI3</name>
+              <description>Level 3 Channel Priority Number</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>RRLVLEN3</name>
+              <description>Level 3 Round-Robin Scheduling Enable</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTPEND</name>
+          <description>Interrupt Pending</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Channel ID</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>TERR</name>
+              <description>Transfer Error</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCMPL</name>
+              <description>Transfer Complete</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SUSP</name>
+              <description>Channel Suspend</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FERR</name>
+              <description>Fetch Error</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSY</name>
+              <description>Busy</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PEND</name>
+              <description>Pending</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTSTATUS</name>
+          <description>Interrupt Status</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>CHINT0</name>
+              <description>Channel 0 Pending Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT1</name>
+              <description>Channel 1 Pending Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT2</name>
+              <description>Channel 2 Pending Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT3</name>
+              <description>Channel 3 Pending Interrupt</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT4</name>
+              <description>Channel 4 Pending Interrupt</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT5</name>
+              <description>Channel 5 Pending Interrupt</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT6</name>
+              <description>Channel 6 Pending Interrupt</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT7</name>
+              <description>Channel 7 Pending Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT8</name>
+              <description>Channel 8 Pending Interrupt</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT9</name>
+              <description>Channel 9 Pending Interrupt</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT10</name>
+              <description>Channel 10 Pending Interrupt</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT11</name>
+              <description>Channel 11 Pending Interrupt</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BUSYCH</name>
+          <description>Busy Channels</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>BUSYCH0</name>
+              <description>Busy Channel 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH1</name>
+              <description>Busy Channel 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH2</name>
+              <description>Busy Channel 2</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH3</name>
+              <description>Busy Channel 3</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH4</name>
+              <description>Busy Channel 4</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH5</name>
+              <description>Busy Channel 5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH6</name>
+              <description>Busy Channel 6</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH7</name>
+              <description>Busy Channel 7</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH8</name>
+              <description>Busy Channel 8</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH9</name>
+              <description>Busy Channel 9</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH10</name>
+              <description>Busy Channel 10</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH11</name>
+              <description>Busy Channel 11</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PENDCH</name>
+          <description>Pending Channels</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>PENDCH0</name>
+              <description>Pending Channel 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH1</name>
+              <description>Pending Channel 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH2</name>
+              <description>Pending Channel 2</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH3</name>
+              <description>Pending Channel 3</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH4</name>
+              <description>Pending Channel 4</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH5</name>
+              <description>Pending Channel 5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH6</name>
+              <description>Pending Channel 6</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH7</name>
+              <description>Pending Channel 7</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH8</name>
+              <description>Pending Channel 8</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH9</name>
+              <description>Pending Channel 9</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH10</name>
+              <description>Pending Channel 10</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH11</name>
+              <description>Pending Channel 11</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ACTIVE</name>
+          <description>Active Channel and Levels</description>
+          <addressOffset>0x30</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>LVLEX0</name>
+              <description>Level 0 Channel Trigger Request Executing</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LVLEX1</name>
+              <description>Level 1 Channel Trigger Request Executing</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LVLEX2</name>
+              <description>Level 2 Channel Trigger Request Executing</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LVLEX3</name>
+              <description>Level 3 Channel Trigger Request Executing</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ID</name>
+              <description>Active Channel ID</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>5</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ABUSY</name>
+              <description>Active Channel Busy</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BTCNT</name>
+              <description>Active Channel Block Transfer Count</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BASEADDR</name>
+          <description>Descriptor Memory Section Base Address</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>BASEADDR</name>
+              <description>Descriptor Memory Base Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WRBADDR</name>
+          <description>Write-Back Memory Section Base Address</description>
+          <addressOffset>0x38</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WRBADDR</name>
+              <description>Write-Back Memory Base Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHID</name>
+          <description>Channel ID</description>
+          <addressOffset>0x3F</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Channel ID</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHCTRLA</name>
+          <description>Channel Control A</description>
+          <addressOffset>0x40</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Channel Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Channel Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHCTRLB</name>
+          <description>Channel Control B</description>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EVACT</name>
+              <description>Event Input Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACTSelect</name>
+                <enumeratedValue>
+                  <name>NOACT</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TRIG</name>
+                  <description>Transfer and periodic transfer trigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CTRIG</name>
+                  <description>Conditional transfer trigger</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CBLOCK</name>
+                  <description>Conditional block transfer</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SUSPEND</name>
+                  <description>Channel suspend operation</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESUME</name>
+                  <description>Channel resume operation</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSKIP</name>
+                  <description>Skip next block suspend action</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>EVIE</name>
+              <description>Channel Event Input Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVOE</name>
+              <description>Channel Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVL</name>
+              <description>Channel Arbitration Level</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>LVLSelect</name>
+                <enumeratedValue>
+                  <name>LVL0</name>
+                  <description>Channel Priority Level 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LVL1</name>
+                  <description>Channel Priority Level 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LVL2</name>
+                  <description>Channel Priority Level 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LVL3</name>
+                  <description>Channel Priority Level 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TRIGSRC</name>
+              <description>Trigger Source</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>6</bitWidth>
+              <enumeratedValues>
+                <name>TRIGSRCSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Only software/event triggers</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TRIGACT</name>
+              <description>Trigger Action</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>TRIGACTSelect</name>
+                <enumeratedValue>
+                  <name>BLOCK</name>
+                  <description>One trigger required for each block transfer</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BEAT</name>
+                  <description>One trigger required for each beat transfer</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TRANSACTION</name>
+                  <description>One trigger required for each transaction</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Software Command</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NOACT</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SUSPEND</name>
+                  <description>Channel suspend operation</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESUME</name>
+                  <description>Channel resume operation</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHINTENCLR</name>
+          <description>Channel Interrupt Enable Clear</description>
+          <addressOffset>0x4C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TERR</name>
+              <description>Channel Transfer Error Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCMPL</name>
+              <description>Channel Transfer Complete Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SUSP</name>
+              <description>Channel Suspend Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHINTENSET</name>
+          <description>Channel Interrupt Enable Set</description>
+          <addressOffset>0x4D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TERR</name>
+              <description>Channel Transfer Error Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCMPL</name>
+              <description>Channel Transfer Complete Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SUSP</name>
+              <description>Channel Suspend Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHINTFLAG</name>
+          <description>Channel Interrupt Flag Status and Clear</description>
+          <addressOffset>0x4E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TERR</name>
+              <description>Channel Transfer Error</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCMPL</name>
+              <description>Channel Transfer Complete</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SUSP</name>
+              <description>Channel Suspend</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHSTATUS</name>
+          <description>Channel Status</description>
+          <addressOffset>0x4F</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>PEND</name>
+              <description>Channel Pending</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSY</name>
+              <description>Channel Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FERR</name>
+              <description>Channel Fetch Error</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>DSU</name>
+      <version>2.0.0</version>
+      <description>Device Service Unit</description>
+      <groupName>DSU</groupName>
+      <prependToName>DSU_</prependToName>
+      <baseAddress>0x41002000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x2000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x0000</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CRC</name>
+              <description>32-bit Cyclic Redundancy Check</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>MBIST</name>
+              <description>Memory Built-In Self-Test</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CE</name>
+              <description>Chip Erase</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSA</name>
+          <description>Status A</description>
+          <addressOffset>0x0001</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DONE</name>
+              <description>Done</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CRSTEXT</name>
+              <description>CPU Reset Phase Extension</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BERR</name>
+              <description>Bus Error</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAIL</name>
+              <description>Failure</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PERR</name>
+              <description>Protection Error</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSB</name>
+          <description>Status B</description>
+          <addressOffset>0x0002</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x10</resetValue>
+          <fields>
+            <field>
+              <name>PROT</name>
+              <description>Protected</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DBGPRES</name>
+              <description>Debugger Present</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DCCD0</name>
+              <description>Debug Communication Channel 0 Dirty</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DCCD1</name>
+              <description>Debug Communication Channel 1 Dirty</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HPE</name>
+              <description>Hot-Plugging Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>Address</description>
+          <addressOffset>0x0004</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>30</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LENGTH</name>
+          <description>Length</description>
+          <addressOffset>0x0008</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>LENGTH</name>
+              <description>Length</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>30</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>Data</description>
+          <addressOffset>0x000C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>DCC%s</name>
+          <description>Debug Communication Channel n</description>
+          <addressOffset>0x0010</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DID</name>
+          <description>Device Identification</description>
+          <addressOffset>0x0018</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x10010300</resetValue>
+          <fields>
+            <field>
+              <name>DEVSEL</name>
+              <description>Device Select</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>REVISION</name>
+              <description>Revision</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DIE</name>
+              <description>Die Identification</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SERIES</name>
+              <description>Product Series</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FAMILY</name>
+              <description>Product Family</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>5</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PROCESSOR</name>
+              <description>Processor</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ENTRY</name>
+          <description>CoreSight ROM Table Entry 0</description>
+          <addressOffset>0x1000</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x9F9FC002</resetValue>
+          <fields>
+            <field>
+              <name>EPRES</name>
+              <description>Entry Present</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FMT</name>
+              <description>Format</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ADDOFF</name>
+              <description>Address Offset</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>20</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ENTRY1</name>
+          <description>CoreSight ROM Table Entry 1</description>
+          <addressOffset>0x1004</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x00003002</resetValue>
+        </register>
+        <register>
+          <name>END</name>
+          <description>CoreSight ROM Table End</description>
+          <addressOffset>0x1008</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>END</name>
+              <description>End Marker</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MEMTYPE</name>
+          <description>CoreSight ROM Table Memory Type</description>
+          <addressOffset>0x1FCC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SMEMP</name>
+              <description>System Memory Present</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID4</name>
+          <description>Peripheral Identification 4</description>
+          <addressOffset>0x1FD0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>JEPCC</name>
+              <description>JEP-106 Continuation Code</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>FKBC</name>
+              <description>4KB Count</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID0</name>
+          <description>Peripheral Identification 0</description>
+          <addressOffset>0x1FE0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x000000D0</resetValue>
+          <fields>
+            <field>
+              <name>PARTNBL</name>
+              <description>Part Number Low</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID1</name>
+          <description>Peripheral Identification 1</description>
+          <addressOffset>0x1FE4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x000000FC</resetValue>
+          <fields>
+            <field>
+              <name>PARTNBH</name>
+              <description>Part Number High</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>JEPIDCL</name>
+              <description>Low part of the JEP-106 Identity Code</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID2</name>
+          <description>Peripheral Identification 2</description>
+          <addressOffset>0x1FE8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x00000009</resetValue>
+          <fields>
+            <field>
+              <name>JEPIDCH</name>
+              <description>JEP-106 Identity Code High</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>JEPU</name>
+              <description>JEP-106 Identity Code is used</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>REVISION</name>
+              <description>Revision Number</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID3</name>
+          <description>Peripheral Identification 3</description>
+          <addressOffset>0x1FEC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>CUSMOD</name>
+              <description>ARM CUSMOD</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>REVAND</name>
+              <description>Revision Number</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CID0</name>
+          <description>Component Identification 0</description>
+          <addressOffset>0x1FF0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x0000000D</resetValue>
+          <fields>
+            <field>
+              <name>PREAMBLEB0</name>
+              <description>Preamble Byte 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CID1</name>
+          <description>Component Identification 1</description>
+          <addressOffset>0x1FF4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x00000010</resetValue>
+          <fields>
+            <field>
+              <name>PREAMBLE</name>
+              <description>Preamble</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CCLASS</name>
+              <description>Component Class</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CID2</name>
+          <description>Component Identification 2</description>
+          <addressOffset>0x1FF8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x00000005</resetValue>
+          <fields>
+            <field>
+              <name>PREAMBLEB2</name>
+              <description>Preamble Byte 2</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CID3</name>
+          <description>Component Identification 3</description>
+          <addressOffset>0x1FFC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x000000B1</resetValue>
+          <fields>
+            <field>
+              <name>PREAMBLEB3</name>
+              <description>Preamble Byte 3</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>EIC</name>
+      <version>1.0.1</version>
+      <description>External Interrupt Controller</description>
+      <groupName>EIC</groupName>
+      <prependToName>EIC_</prependToName>
+      <baseAddress>0x40001800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>EIC</name>
+        <value>4</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x01</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>NMICTRL</name>
+          <description>Non-Maskable Interrupt Control</description>
+          <addressOffset>0x02</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>NMISENSE</name>
+              <description>Non-Maskable Interrupt Sense</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>NMISENSESelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising-edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling-edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both-edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High-level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low-level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>NMIFILTEN</name>
+              <description>Non-Maskable Interrupt Filter Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>NMIFLAG</name>
+          <description>Non-Maskable Interrupt Flag Status and Clear</description>
+          <addressOffset>0x03</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>NMI</name>
+              <description>Non-Maskable Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EXTINTEO0</name>
+              <description>External Interrupt 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO1</name>
+              <description>External Interrupt 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO2</name>
+              <description>External Interrupt 2 Event Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO3</name>
+              <description>External Interrupt 3 Event Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO4</name>
+              <description>External Interrupt 4 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO5</name>
+              <description>External Interrupt 5 Event Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO6</name>
+              <description>External Interrupt 6 Event Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO7</name>
+              <description>External Interrupt 7 Event Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO8</name>
+              <description>External Interrupt 8 Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO9</name>
+              <description>External Interrupt 9 Event Output Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO10</name>
+              <description>External Interrupt 10 Event Output Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO11</name>
+              <description>External Interrupt 11 Event Output Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO12</name>
+              <description>External Interrupt 12 Event Output Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO13</name>
+              <description>External Interrupt 13 Event Output Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO14</name>
+              <description>External Interrupt 14 Event Output Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO15</name>
+              <description>External Interrupt 15 Event Output Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EXTINT0</name>
+              <description>External Interrupt 0 Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT1</name>
+              <description>External Interrupt 1 Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT2</name>
+              <description>External Interrupt 2 Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT3</name>
+              <description>External Interrupt 3 Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT4</name>
+              <description>External Interrupt 4 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT5</name>
+              <description>External Interrupt 5 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT6</name>
+              <description>External Interrupt 6 Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT7</name>
+              <description>External Interrupt 7 Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT8</name>
+              <description>External Interrupt 8 Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT9</name>
+              <description>External Interrupt 9 Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT10</name>
+              <description>External Interrupt 10 Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT11</name>
+              <description>External Interrupt 11 Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT12</name>
+              <description>External Interrupt 12 Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT13</name>
+              <description>External Interrupt 13 Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT14</name>
+              <description>External Interrupt 14 Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT15</name>
+              <description>External Interrupt 15 Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EXTINT0</name>
+              <description>External Interrupt 0 Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT1</name>
+              <description>External Interrupt 1 Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT2</name>
+              <description>External Interrupt 2 Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT3</name>
+              <description>External Interrupt 3 Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT4</name>
+              <description>External Interrupt 4 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT5</name>
+              <description>External Interrupt 5 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT6</name>
+              <description>External Interrupt 6 Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT7</name>
+              <description>External Interrupt 7 Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT8</name>
+              <description>External Interrupt 8 Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT9</name>
+              <description>External Interrupt 9 Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT10</name>
+              <description>External Interrupt 10 Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT11</name>
+              <description>External Interrupt 11 Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT12</name>
+              <description>External Interrupt 12 Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT13</name>
+              <description>External Interrupt 13 Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT14</name>
+              <description>External Interrupt 14 Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT15</name>
+              <description>External Interrupt 15 Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EXTINT0</name>
+              <description>External Interrupt 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT1</name>
+              <description>External Interrupt 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT2</name>
+              <description>External Interrupt 2</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT3</name>
+              <description>External Interrupt 3</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT4</name>
+              <description>External Interrupt 4</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT5</name>
+              <description>External Interrupt 5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT6</name>
+              <description>External Interrupt 6</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT7</name>
+              <description>External Interrupt 7</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT8</name>
+              <description>External Interrupt 8</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT9</name>
+              <description>External Interrupt 9</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT10</name>
+              <description>External Interrupt 10</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT11</name>
+              <description>External Interrupt 11</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT12</name>
+              <description>External Interrupt 12</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT13</name>
+              <description>External Interrupt 13</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT14</name>
+              <description>External Interrupt 14</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT15</name>
+              <description>External Interrupt 15</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WAKEUP</name>
+          <description>Wake-Up Enable</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WAKEUPEN0</name>
+              <description>External Interrupt 0 Wake-up Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN1</name>
+              <description>External Interrupt 1 Wake-up Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN2</name>
+              <description>External Interrupt 2 Wake-up Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN3</name>
+              <description>External Interrupt 3 Wake-up Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN4</name>
+              <description>External Interrupt 4 Wake-up Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN5</name>
+              <description>External Interrupt 5 Wake-up Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN6</name>
+              <description>External Interrupt 6 Wake-up Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN7</name>
+              <description>External Interrupt 7 Wake-up Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN8</name>
+              <description>External Interrupt 8 Wake-up Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN9</name>
+              <description>External Interrupt 9 Wake-up Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN10</name>
+              <description>External Interrupt 10 Wake-up Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN11</name>
+              <description>External Interrupt 11 Wake-up Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN12</name>
+              <description>External Interrupt 12 Wake-up Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN13</name>
+              <description>External Interrupt 13 Wake-up Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN14</name>
+              <description>External Interrupt 14 Wake-up Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN15</name>
+              <description>External Interrupt 15 Wake-up Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CONFIG%s</name>
+          <description>Configuration n</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SENSE0</name>
+              <description>Input Sense 0 Configuration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE0Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising-edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling-edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both-edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High-level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low-level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN0</name>
+              <description>Filter 0 Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE1</name>
+              <description>Input Sense 1 Configuration</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE1Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN1</name>
+              <description>Filter 1 Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE2</name>
+              <description>Input Sense 2 Configuration</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE2Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN2</name>
+              <description>Filter 2 Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE3</name>
+              <description>Input Sense 3 Configuration</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE3Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN3</name>
+              <description>Filter 3 Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE4</name>
+              <description>Input Sense 4 Configuration</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE4Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN4</name>
+              <description>Filter 4 Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE5</name>
+              <description>Input Sense 5 Configuration</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE5Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN5</name>
+              <description>Filter 5 Enable</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE6</name>
+              <description>Input Sense 6 Configuration</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE6Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN6</name>
+              <description>Filter 6 Enable</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE7</name>
+              <description>Input Sense 7 Configuration</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE7Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN7</name>
+              <description>Filter 7 Enable</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>EVSYS</name>
+      <version>1.0.1</version>
+      <description>Event System Interface</description>
+      <groupName>EVSYS</groupName>
+      <prependToName>EVSYS_</prependToName>
+      <baseAddress>0x42000400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>EVSYS</name>
+        <value>8</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>GCLKREQ</name>
+              <description>Generic Clock Requests</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHANNEL</name>
+          <description>Channel</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CHANNEL</name>
+              <description>Channel Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>SWEVT</name>
+              <description>Software Event</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVGEN</name>
+              <description>Event Generator Selection</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+            <field>
+              <name>PATH</name>
+              <description>Path Selection</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PATHSelect</name>
+                <enumeratedValue>
+                  <name>SYNCHRONOUS</name>
+                  <description>Synchronous path</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNCHRONIZED</name>
+                  <description>Resynchronized path</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ASYNCHRONOUS</name>
+                  <description>Asynchronous path</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>EDGSEL</name>
+              <description>Edge Detection Selection</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>EDGSELSelect</name>
+                <enumeratedValue>
+                  <name>NO_EVT_OUTPUT</name>
+                  <description>No event output when using the resynchronized or synchronous path</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISING_EDGE</name>
+                  <description>Event detection only on the rising edge of the signal from the event generator when using the resynchronized or synchronous path</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALLING_EDGE</name>
+                  <description>Event detection only on the falling edge of the signal from the event generator when using the resynchronized or synchronous path</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH_EDGES</name>
+                  <description>Event detection on rising and falling edges of the signal from the event generator when using the resynchronized or synchronous path</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>USER</name>
+          <description>User Multiplexer</description>
+          <addressOffset>0x08</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USER</name>
+              <description>User Multiplexer Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>CHANNEL</name>
+              <description>Channel Event Selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>CHANNELSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>No Channel Output Selected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHSTATUS</name>
+          <description>Channel Status</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x000F00FF</resetValue>
+          <fields>
+            <field>
+              <name>USRRDY0</name>
+              <description>Channel 0 User Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY1</name>
+              <description>Channel 1 User Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY2</name>
+              <description>Channel 2 User Ready</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY3</name>
+              <description>Channel 3 User Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY4</name>
+              <description>Channel 4 User Ready</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY5</name>
+              <description>Channel 5 User Ready</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY6</name>
+              <description>Channel 6 User Ready</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY7</name>
+              <description>Channel 7 User Ready</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY0</name>
+              <description>Channel 0 Busy</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY1</name>
+              <description>Channel 1 Busy</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY2</name>
+              <description>Channel 2 Busy</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY3</name>
+              <description>Channel 3 Busy</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY4</name>
+              <description>Channel 4 Busy</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY5</name>
+              <description>Channel 5 Busy</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY6</name>
+              <description>Channel 6 Busy</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY7</name>
+              <description>Channel 7 Busy</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY8</name>
+              <description>Channel 8 User Ready</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY9</name>
+              <description>Channel 9 User Ready</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY10</name>
+              <description>Channel 10 User Ready</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY11</name>
+              <description>Channel 11 User Ready</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY8</name>
+              <description>Channel 8 Busy</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY9</name>
+              <description>Channel 9 Busy</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY10</name>
+              <description>Channel 10 Busy</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY11</name>
+              <description>Channel 11 Busy</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVR0</name>
+              <description>Channel 0 Overrun Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR1</name>
+              <description>Channel 1 Overrun Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR2</name>
+              <description>Channel 2 Overrun Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR3</name>
+              <description>Channel 3 Overrun Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR4</name>
+              <description>Channel 4 Overrun Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR5</name>
+              <description>Channel 5 Overrun Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR6</name>
+              <description>Channel 6 Overrun Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR7</name>
+              <description>Channel 7 Overrun Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD0</name>
+              <description>Channel 0 Event Detection Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD1</name>
+              <description>Channel 1 Event Detection Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD2</name>
+              <description>Channel 2 Event Detection Interrupt Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD3</name>
+              <description>Channel 3 Event Detection Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD4</name>
+              <description>Channel 4 Event Detection Interrupt Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD5</name>
+              <description>Channel 5 Event Detection Interrupt Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD6</name>
+              <description>Channel 6 Event Detection Interrupt Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD7</name>
+              <description>Channel 7 Event Detection Interrupt Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR8</name>
+              <description>Channel 8 Overrun Interrupt Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR9</name>
+              <description>Channel 9 Overrun Interrupt Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR10</name>
+              <description>Channel 10 Overrun Interrupt Enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR11</name>
+              <description>Channel 11 Overrun Interrupt Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD8</name>
+              <description>Channel 8 Event Detection Interrupt Enable</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD9</name>
+              <description>Channel 9 Event Detection Interrupt Enable</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD10</name>
+              <description>Channel 10 Event Detection Interrupt Enable</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD11</name>
+              <description>Channel 11 Event Detection Interrupt Enable</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVR0</name>
+              <description>Channel 0 Overrun Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR1</name>
+              <description>Channel 1 Overrun Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR2</name>
+              <description>Channel 2 Overrun Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR3</name>
+              <description>Channel 3 Overrun Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR4</name>
+              <description>Channel 4 Overrun Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR5</name>
+              <description>Channel 5 Overrun Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR6</name>
+              <description>Channel 6 Overrun Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR7</name>
+              <description>Channel 7 Overrun Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD0</name>
+              <description>Channel 0 Event Detection Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD1</name>
+              <description>Channel 1 Event Detection Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD2</name>
+              <description>Channel 2 Event Detection Interrupt Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD3</name>
+              <description>Channel 3 Event Detection Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD4</name>
+              <description>Channel 4 Event Detection Interrupt Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD5</name>
+              <description>Channel 5 Event Detection Interrupt Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD6</name>
+              <description>Channel 6 Event Detection Interrupt Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD7</name>
+              <description>Channel 7 Event Detection Interrupt Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR8</name>
+              <description>Channel 8 Overrun Interrupt Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR9</name>
+              <description>Channel 9 Overrun Interrupt Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR10</name>
+              <description>Channel 10 Overrun Interrupt Enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR11</name>
+              <description>Channel 11 Overrun Interrupt Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD8</name>
+              <description>Channel 8 Event Detection Interrupt Enable</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD9</name>
+              <description>Channel 9 Event Detection Interrupt Enable</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD10</name>
+              <description>Channel 10 Event Detection Interrupt Enable</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD11</name>
+              <description>Channel 11 Event Detection Interrupt Enable</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVR0</name>
+              <description>Channel 0 Overrun</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR1</name>
+              <description>Channel 1 Overrun</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR2</name>
+              <description>Channel 2 Overrun</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR3</name>
+              <description>Channel 3 Overrun</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR4</name>
+              <description>Channel 4 Overrun</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR5</name>
+              <description>Channel 5 Overrun</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR6</name>
+              <description>Channel 6 Overrun</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR7</name>
+              <description>Channel 7 Overrun</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD0</name>
+              <description>Channel 0 Event Detection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD1</name>
+              <description>Channel 1 Event Detection</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD2</name>
+              <description>Channel 2 Event Detection</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD3</name>
+              <description>Channel 3 Event Detection</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD4</name>
+              <description>Channel 4 Event Detection</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD5</name>
+              <description>Channel 5 Event Detection</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD6</name>
+              <description>Channel 6 Event Detection</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD7</name>
+              <description>Channel 7 Event Detection</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR8</name>
+              <description>Channel 8 Overrun</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR9</name>
+              <description>Channel 9 Overrun</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR10</name>
+              <description>Channel 10 Overrun</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR11</name>
+              <description>Channel 11 Overrun</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD8</name>
+              <description>Channel 8 Event Detection</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD9</name>
+              <description>Channel 9 Event Detection</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD10</name>
+              <description>Channel 10 Event Detection</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD11</name>
+              <description>Channel 11 Event Detection</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>GCLK</name>
+      <version>2.1.0</version>
+      <description>Generic Clock Generator</description>
+      <groupName>GCLK</groupName>
+      <prependToName>GCLK_</prependToName>
+      <baseAddress>0x40000C00</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x0</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x1</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy Status</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CLKCTRL</name>
+          <description>Generic Clock Control</description>
+          <addressOffset>0x2</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Generic Clock Selection ID</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <enumeratedValues>
+                <name>IDSelect</name>
+                <enumeratedValue>
+                  <name>DFLL48</name>
+                  <description>DFLL48</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FDPLL</name>
+                  <description>FDPLL</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FDPLL32K</name>
+                  <description>FDPLL32K</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WDT</name>
+                  <description>WDT</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RTC</name>
+                  <description>RTC</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EIC</name>
+                  <description>EIC</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB</name>
+                  <description>USB</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_0</name>
+                  <description>EVSYS_0</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_1</name>
+                  <description>EVSYS_1</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_2</name>
+                  <description>EVSYS_2</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_3</name>
+                  <description>EVSYS_3</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_4</name>
+                  <description>EVSYS_4</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_5</name>
+                  <description>EVSYS_5</description>
+                  <value>0xc</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_6</name>
+                  <description>EVSYS_6</description>
+                  <value>0xd</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_7</name>
+                  <description>EVSYS_7</description>
+                  <value>0xe</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_8</name>
+                  <description>EVSYS_8</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_9</name>
+                  <description>EVSYS_9</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_10</name>
+                  <description>EVSYS_10</description>
+                  <value>0x11</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_11</name>
+                  <description>EVSYS_11</description>
+                  <value>0x12</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SERCOMX_SLOW</name>
+                  <description>SERCOMX_SLOW</description>
+                  <value>0x13</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SERCOM0_CORE</name>
+                  <description>SERCOM0_CORE</description>
+                  <value>0x14</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SERCOM1_CORE</name>
+                  <description>SERCOM1_CORE</description>
+                  <value>0x15</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SERCOM2_CORE</name>
+                  <description>SERCOM2_CORE</description>
+                  <value>0x16</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SERCOM3_CORE</name>
+                  <description>SERCOM3_CORE</description>
+                  <value>0x17</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SERCOM4_CORE</name>
+                  <description>SERCOM4_CORE</description>
+                  <value>0x18</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SERCOM5_CORE</name>
+                  <description>SERCOM5_CORE</description>
+                  <value>0x19</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TCC0_TCC1</name>
+                  <description>TCC0_TCC1</description>
+                  <value>0x1a</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TCC2_TC3</name>
+                  <description>TCC2_TC3</description>
+                  <value>0x1b</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TC4_TC5</name>
+                  <description>TC4_TC5</description>
+                  <value>0x1c</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TC6_TC7</name>
+                  <description>TC6_TC7</description>
+                  <value>0x1d</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC</name>
+                  <description>ADC</description>
+                  <value>0x1e</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AC_DIG</name>
+                  <description>AC_DIG</description>
+                  <value>0x1f</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AC_ANA</name>
+                  <description>AC_ANA</description>
+                  <value>0x20</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DAC</name>
+                  <description>DAC</description>
+                  <value>0x21</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2S_0</name>
+                  <description>I2S_0</description>
+                  <value>0x23</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2S_1</name>
+                  <description>I2S_1</description>
+                  <value>0x24</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>GEN</name>
+              <description>Generic Clock Generator</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>GENSelect</name>
+                <enumeratedValue>
+                  <name>GCLK0</name>
+                  <description>Generic clock generator 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK1</name>
+                  <description>Generic clock generator 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK2</name>
+                  <description>Generic clock generator 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK3</name>
+                  <description>Generic clock generator 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK4</name>
+                  <description>Generic clock generator 4</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK5</name>
+                  <description>Generic clock generator 5</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK6</name>
+                  <description>Generic clock generator 6</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK7</name>
+                  <description>Generic clock generator 7</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK8</name>
+                  <description>Generic clock generator 8</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CLKEN</name>
+              <description>Clock Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WRTLOCK</name>
+              <description>Write Lock</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>GENCTRL</name>
+          <description>Generic Clock Generator Control</description>
+          <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Generic Clock Generator Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>SRC</name>
+              <description>Source Select</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>SRCSelect</name>
+                <enumeratedValue>
+                  <name>XOSC</name>
+                  <description>XOSC oscillator output</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLKIN</name>
+                  <description>Generator input pad</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLKGEN1</name>
+                  <description>Generic clock generator 1 output</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OSCULP32K</name>
+                  <description>OSCULP32K oscillator output</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OSC32K</name>
+                  <description>OSC32K oscillator output</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>XOSC32K</name>
+                  <description>XOSC32K oscillator output</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OSC8M</name>
+                  <description>OSC8M oscillator output</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DFLL48M</name>
+                  <description>DFLL48M output</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DPLL96M</name>
+                  <description>DPLL96M output</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>GENEN</name>
+              <description>Generic Clock Generator Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IDC</name>
+              <description>Improve Duty Cycle</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OOV</name>
+              <description>Output Off Value</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OE</name>
+              <description>Output Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DIVSEL</name>
+              <description>Divide Selection</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>GENDIV</name>
+          <description>Generic Clock Generator Division</description>
+          <addressOffset>0x8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Generic Clock Generator Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>DIV</name>
+              <description>Division Factor</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>HMATRIX</name>
+      <version>2.1.2</version>
+      <description>HSB Matrix</description>
+      <groupName>HMATRIXB</groupName>
+      <prependToName>HMATRIXB_</prependToName>
+      <baseAddress>0x41007000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <dim>16</dim>
+          <dimIncrement>0x8</dimIncrement>
+          <name>PRAS%s</name>
+          <description>Priority A for Slave</description>
+          <addressOffset>0x080</addressOffset>
+          <size>32</size>
+        </register>
+        <register>
+          <dim>16</dim>
+          <dimIncrement>0x8</dimIncrement>
+          <name>PRBS%s</name>
+          <description>Priority B for Slave</description>
+          <addressOffset>0x084</addressOffset>
+          <size>32</size>
+        </register>
+        <register>
+          <dim>16</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>SFR%s</name>
+          <description>Special Function</description>
+          <addressOffset>0x110</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SFR</name>
+              <description>Special Function Register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>I2S</name>
+      <version>1.0.2</version>
+      <description>Inter-IC Sound Interface</description>
+      <groupName>I2S</groupName>
+      <prependToName>I2S_</prependToName>
+      <baseAddress>0x42005000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>I2S</name>
+        <value>27</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CKEN0</name>
+              <description>Clock Unit 0 Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CKEN1</name>
+              <description>Clock Unit 1 Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SEREN0</name>
+              <description>Serializer 0 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SEREN1</name>
+              <description>Serializer 1 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CLKCTRL%s</name>
+          <description>Clock Unit n Control</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SLOTSIZE</name>
+              <description>Slot Size</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SLOTSIZESelect</name>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8-bit Slot for Clock Unit n</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16-bit Slot for Clock Unit n</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>24</name>
+                  <description>24-bit Slot for Clock Unit n</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32-bit Slot for Clock Unit n</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>NBSLOTS</name>
+              <description>Number of Slots in Frame</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>FSWIDTH</name>
+              <description>Frame Sync Width</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>FSWIDTHSelect</name>
+                <enumeratedValue>
+                  <name>SLOT</name>
+                  <description>Frame Sync Pulse is 1 Slot wide (default for I2S protocol)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HALF</name>
+                  <description>Frame Sync Pulse is half a Frame wide</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BIT</name>
+                  <description>Frame Sync Pulse is 1 Bit wide</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BURST</name>
+                  <description>Clock Unit n operates in Burst mode, with a 1-bit wide Frame Sync pulse per Data sample, only when Data transfer is requested</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>BITDELAY</name>
+              <description>Data Delay from Frame Sync</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <name>BITDELAYSelect</name>
+                <enumeratedValue>
+                  <name>LJ</name>
+                  <description>Left Justified (0 Bit Delay)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2S</name>
+                  <description>I2S (1 Bit Delay)</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FSSEL</name>
+              <description>Frame Sync Select</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <name>FSSELSelect</name>
+                <enumeratedValue>
+                  <name>SCKDIV</name>
+                  <description>Divided Serial Clock n is used as Frame Sync n source</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FSPIN</name>
+                  <description>FSn input pin is used as Frame Sync n source</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FSINV</name>
+              <description>Frame Sync Invert</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SCKSEL</name>
+              <description>Serial Clock Select</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <name>SCKSELSelect</name>
+                <enumeratedValue>
+                  <name>MCKDIV</name>
+                  <description>Divided Master Clock n is used as Serial Clock n source</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SCKPIN</name>
+                  <description>SCKn input pin is used as Serial Clock n source</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MCKSEL</name>
+              <description>Master Clock Select</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <name>MCKSELSelect</name>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>GCLK_I2S_n is used as Master Clock n source</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MCKPIN</name>
+                  <description>MCKn input pin is used as Master Clock n source</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MCKEN</name>
+              <description>Master Clock Enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCKDIV</name>
+              <description>Master Clock Division Factor</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>MCKOUTDIV</name>
+              <description>Master Clock Output Division Factor</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>FSOUTINV</name>
+              <description>Frame Sync Output Invert</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SCKOUTINV</name>
+              <description>Serial Clock Output Invert</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCKOUTINV</name>
+              <description>Master Clock Output Invert</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>RXRDY0</name>
+              <description>Receive Ready 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXRDY1</name>
+              <description>Receive Ready 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXOR0</name>
+              <description>Receive Overrun 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXOR1</name>
+              <description>Receive Overrun 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXRDY0</name>
+              <description>Transmit Ready 0 Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXRDY1</name>
+              <description>Transmit Ready 1 Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXUR0</name>
+              <description>Transmit Underrun 0 Interrupt Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXUR1</name>
+              <description>Transmit Underrun 1 Interrupt Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>RXRDY0</name>
+              <description>Receive Ready 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXRDY1</name>
+              <description>Receive Ready 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXOR0</name>
+              <description>Receive Overrun 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXOR1</name>
+              <description>Receive Overrun 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXRDY0</name>
+              <description>Transmit Ready 0 Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXRDY1</name>
+              <description>Transmit Ready 1 Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXUR0</name>
+              <description>Transmit Underrun 0 Interrupt Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXUR1</name>
+              <description>Transmit Underrun 1 Interrupt Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>RXRDY0</name>
+              <description>Receive Ready 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXRDY1</name>
+              <description>Receive Ready 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXOR0</name>
+              <description>Receive Overrun 0</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXOR1</name>
+              <description>Receive Overrun 1</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXRDY0</name>
+              <description>Transmit Ready 0</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXRDY1</name>
+              <description>Transmit Ready 1</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXUR0</name>
+              <description>Transmit Underrun 0</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXUR1</name>
+              <description>Transmit Underrun 1</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>Synchronization Status</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Status</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable Synchronization Status</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CKEN0</name>
+              <description>Clock Unit 0 Enable Synchronization Status</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CKEN1</name>
+              <description>Clock Unit 1 Enable Synchronization Status</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SEREN0</name>
+              <description>Serializer 0 Enable Synchronization Status</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SEREN1</name>
+              <description>Serializer 1 Enable Synchronization Status</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DATA0</name>
+              <description>Data 0 Synchronization Status</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DATA1</name>
+              <description>Data 1 Synchronization Status</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>SERCTRL%s</name>
+          <description>Serializer n Control</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SERMODE</name>
+              <description>Serializer Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SERMODESelect</name>
+                <enumeratedValue>
+                  <name>RX</name>
+                  <description>Receive</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TX</name>
+                  <description>Transmit</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PDM2</name>
+                  <description>Receive one PDM data on each serial clock edge</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TXDEFAULT</name>
+              <description>Line Default Line when Slot Disabled</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>TXDEFAULTSelect</name>
+                <enumeratedValue>
+                  <name>ZERO</name>
+                  <description>Output Default Value is 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ONE</name>
+                  <description>Output Default Value is 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIZ</name>
+                  <description>Output Default Value is high impedance</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TXSAME</name>
+              <description>Transmit Data when Underrun</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <name>TXSAMESelect</name>
+                <enumeratedValue>
+                  <name>ZERO</name>
+                  <description>Zero data transmitted in case of underrun</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SAME</name>
+                  <description>Last data transmitted in case of underrun</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CLKSEL</name>
+              <description>Clock Unit Selection</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <name>CLKSELSelect</name>
+                <enumeratedValue>
+                  <name>CLK0</name>
+                  <description>Use Clock Unit 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLK1</name>
+                  <description>Use Clock Unit 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SLOTADJ</name>
+              <description>Data Slot Formatting Adjust</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <name>SLOTADJSelect</name>
+                <enumeratedValue>
+                  <name>RIGHT</name>
+                  <description>Data is right adjusted in slot</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LEFT</name>
+                  <description>Data is left adjusted in slot</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>DATASIZE</name>
+              <description>Data Word Size</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>DATASIZESelect</name>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 bits</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>24</name>
+                  <description>24 bits</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>20</name>
+                  <description>20 bits</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>18</name>
+                  <description>18 bits</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 bits</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16C</name>
+                  <description>16 bits compact stereo</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 bits</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8C</name>
+                  <description>8 bits compact stereo</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>WORDADJ</name>
+              <description>Data Word Formatting Adjust</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <name>WORDADJSelect</name>
+                <enumeratedValue>
+                  <name>RIGHT</name>
+                  <description>Data is right adjusted in word</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LEFT</name>
+                  <description>Data is left adjusted in word</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>EXTEND</name>
+              <description>Data Formatting Bit Extension</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>EXTENDSelect</name>
+                <enumeratedValue>
+                  <name>ZERO</name>
+                  <description>Extend with zeroes</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ONE</name>
+                  <description>Extend with ones</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MSBIT</name>
+                  <description>Extend with Most Significant Bit</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LSBIT</name>
+                  <description>Extend with Least Significant Bit</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>BITREV</name>
+              <description>Data Formatting Bit Reverse</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <name>BITREVSelect</name>
+                <enumeratedValue>
+                  <name>MSBIT</name>
+                  <description>Transfer Data Most Significant Bit (MSB) first (default for I2S protocol)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LSBIT</name>
+                  <description>Transfer Data Least Significant Bit (LSB) first</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SLOTDIS0</name>
+              <description>Slot 0 Disabled for this Serializer</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SLOTDIS1</name>
+              <description>Slot 1 Disabled for this Serializer</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SLOTDIS2</name>
+              <description>Slot 2 Disabled for this Serializer</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SLOTDIS3</name>
+              <description>Slot 3 Disabled for this Serializer</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SLOTDIS4</name>
+              <description>Slot 4 Disabled for this Serializer</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SLOTDIS5</name>
+              <description>Slot 5 Disabled for this Serializer</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SLOTDIS6</name>
+              <description>Slot 6 Disabled for this Serializer</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SLOTDIS7</name>
+              <description>Slot 7 Disabled for this Serializer</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MONO</name>
+              <description>Mono Mode</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <name>MONOSelect</name>
+                <enumeratedValue>
+                  <name>STEREO</name>
+                  <description>Normal mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MONO</name>
+                  <description>Left channel data is duplicated to right channel</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>DMA</name>
+              <description>Single or Multiple DMA Channels</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <name>DMASelect</name>
+                <enumeratedValue>
+                  <name>SINGLE</name>
+                  <description>Single DMA channel</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MULTIPLE</name>
+                  <description>One DMA channel per data channel</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RXLOOP</name>
+              <description>Loop-back Test Mode</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>DATA%s</name>
+          <description>Data n</description>
+          <addressOffset>0x30</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Sample Data</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>MTB</name>
+      <version>1.0.0</version>
+      <description>Cortex-M0+ Micro-Trace Buffer</description>
+      <groupName>MTB</groupName>
+      <prependToName>MTB_</prependToName>
+      <baseAddress>0x41006000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x1000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>POSITION</name>
+          <description>MTB Position</description>
+          <addressOffset>0x000</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WRAP</name>
+              <description>Pointer Value Wraps</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POINTER</name>
+              <description>Trace Packet Location Pointer</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>29</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MASTER</name>
+          <description>MTB Master</description>
+          <addressOffset>0x004</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>MASK</name>
+              <description>Maximum Value of the Trace Buffer in SRAM</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>TSTARTEN</name>
+              <description>Trace Start Input Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TSTOPEN</name>
+              <description>Trace Stop Input Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SFRWPRIV</name>
+              <description>Special Function Register Write Privilege</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RAMPRIV</name>
+              <description>SRAM Privilege</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HALTREQ</name>
+              <description>Halt Request</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN</name>
+              <description>Main Trace Enable</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FLOW</name>
+          <description>MTB Flow</description>
+          <addressOffset>0x008</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>AUTOSTOP</name>
+              <description>Auto Stop Tracing</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AUTOHALT</name>
+              <description>Auto Halt Request</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WATERMARK</name>
+              <description>Watermark value</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>29</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BASE</name>
+          <description>MTB Base</description>
+          <addressOffset>0x00C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>ITCTRL</name>
+          <description>MTB Integration Mode Control</description>
+          <addressOffset>0xF00</addressOffset>
+          <size>32</size>
+        </register>
+        <register>
+          <name>CLAIMSET</name>
+          <description>MTB Claim Set</description>
+          <addressOffset>0xFA0</addressOffset>
+          <size>32</size>
+        </register>
+        <register>
+          <name>CLAIMCLR</name>
+          <description>MTB Claim Clear</description>
+          <addressOffset>0xFA4</addressOffset>
+          <size>32</size>
+        </register>
+        <register>
+          <name>LOCKACCESS</name>
+          <description>MTB Lock Access</description>
+          <addressOffset>0xFB0</addressOffset>
+          <size>32</size>
+        </register>
+        <register>
+          <name>LOCKSTATUS</name>
+          <description>MTB Lock Status</description>
+          <addressOffset>0xFB4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>AUTHSTATUS</name>
+          <description>MTB Authentication Status</description>
+          <addressOffset>0xFB8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>DEVARCH</name>
+          <description>MTB Device Architecture</description>
+          <addressOffset>0xFBC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>DEVID</name>
+          <description>MTB Device Configuration</description>
+          <addressOffset>0xFC8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>DEVTYPE</name>
+          <description>MTB Device Type</description>
+          <addressOffset>0xFCC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID4</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFD0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID5</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFD4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID6</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFD8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID7</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFDC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID0</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFE0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID1</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFE4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID2</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFE8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID3</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFEC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>CID0</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFF0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>CID1</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFF4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>CID2</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFF8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>CID3</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFFC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>NVMCTRL</name>
+      <version>1.0.6</version>
+      <description>Non-Volatile Memory Controller</description>
+      <groupName>NVMCTRL</groupName>
+      <prependToName>NVMCTRL_</prependToName>
+      <baseAddress>0x41004000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>NVMCTRL</name>
+        <value>5</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>ER</name>
+                  <description>Erase Row - Erases the row addressed by the ADDR register.</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WP</name>
+                  <description>Write Page - Writes the contents of the page buffer to the page addressed by the ADDR register.</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EAR</name>
+                  <description>Erase Auxiliary Row - Erases the auxiliary row addressed by the ADDR register. This command can be given only when the security bit is not set and only to the user configuration row.</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WAP</name>
+                  <description>Write Auxiliary Page - Writes the contents of the page buffer to the page addressed by the ADDR register. This command can be given only when the security bit is not set and only to the user configuration row.</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SF</name>
+                  <description>Security Flow Command</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WL</name>
+                  <description>Write lockbits</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LR</name>
+                  <description>Lock Region - Locks the region containing the address location in the ADDR register.</description>
+                  <value>0x40</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UR</name>
+                  <description>Unlock Region - Unlocks the region containing the address location in the ADDR register.</description>
+                  <value>0x41</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPRM</name>
+                  <description>Sets the power reduction mode.</description>
+                  <value>0x42</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CPRM</name>
+                  <description>Clears the power reduction mode.</description>
+                  <value>0x43</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PBC</name>
+                  <description>Page Buffer Clear - Clears the page buffer.</description>
+                  <value>0x44</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSB</name>
+                  <description>Set Security Bit - Sets the security bit by writing 0x00 to the first byte in the lockbit row.</description>
+                  <value>0x45</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INVALL</name>
+                  <description>Invalidates all cache lines.</description>
+                  <value>0x46</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CMDEX</name>
+              <description>Command Execution</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>8</bitWidth>
+              <enumeratedValues>
+                <name>CMDEXSelect</name>
+                <enumeratedValue>
+                  <name>KEY</name>
+                  <description>Execution Key</description>
+                  <value>0xa5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>RWS</name>
+              <description>NVM Read Wait States</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>RWSSelect</name>
+                <enumeratedValue>
+                  <name>SINGLE</name>
+                  <description>Single Auto Wait State</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HALF</name>
+                  <description>Half Auto Wait State</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DUAL</name>
+                  <description>Dual Auto Wait State</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MANW</name>
+              <description>Manual Write</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SLEEPPRM</name>
+              <description>Power Reduction Mode during Sleep</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SLEEPPRMSelect</name>
+                <enumeratedValue>
+                  <name>WAKEONACCESS</name>
+                  <description>NVM block enters low-power mode when entering sleep.NVM block exits low-power mode upon first access.</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WAKEUPINSTANT</name>
+                  <description>NVM block enters low-power mode when entering sleep.NVM block exits low-power mode when exiting sleep.</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DISABLED</name>
+                  <description>Auto power reduction disabled.</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>READMODE</name>
+              <description>NVMCTRL Read Mode</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>READMODESelect</name>
+                <enumeratedValue>
+                  <name>NO_MISS_PENALTY</name>
+                  <description>The NVM Controller (cache system) does not insert wait states on a cache miss. Gives the best system performance.</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW_POWER</name>
+                  <description>Reduces power consumption of the cache system, but inserts a wait state each time there is a cache miss. This mode may not be relevant if CPU performance is required, as the application will be stalled and may lead to increase run time.</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DETERMINISTIC</name>
+                  <description>The cache system ensures that a cache hit or miss takes the same amount of time, determined by the number of programmed flash wait states. This mode can be used for real-time applications that require deterministic execution timings.</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CACHEDIS</name>
+              <description>Cache Disable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PARAM</name>
+          <description>NVM Parameter</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>NVMP</name>
+              <description>NVM Pages</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PSZ</name>
+              <description>Page Size</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>PSZSelect</name>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 bytes</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 bytes</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 bytes</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 bytes</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 bytes</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 bytes</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 bytes</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1024</name>
+                  <description>1024 bytes</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>READY</name>
+              <description>NVM Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x10</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>READY</name>
+              <description>NVM Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>READY</name>
+              <description>NVM Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PRM</name>
+              <description>Power Reduction Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LOAD</name>
+              <description>NVM Page Buffer Active Loading</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PROGE</name>
+              <description>Programming Error Status</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LOCKE</name>
+              <description>Lock Error Status</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NVME</name>
+              <description>NVM Error</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SB</name>
+              <description>Security Bit Status</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>Address</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>NVM Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>22</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LOCK</name>
+          <description>Lock Section</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>LOCK</name>
+              <description>Region Lock Bits</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>PAC0</name>
+      <version>1.0.1</version>
+      <description>Peripheral Access Controller 0</description>
+      <groupName>PAC</groupName>
+      <prependToName>PAC_</prependToName>
+      <baseAddress>0x40000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x08</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>WPCLR</name>
+          <description>Write Protection Clear</description>
+          <addressOffset>0x0</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WP</name>
+              <description>Write Protection Clear</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>31</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WPSET</name>
+          <description>Write Protection Set</description>
+          <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WP</name>
+              <description>Write Protection Set</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>31</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="PAC0">
+      <name>PAC1</name>
+      <description>Peripheral Access Controller 1</description>
+      <baseAddress>0x41000000</baseAddress>
+    </peripheral>
+    <peripheral derivedFrom="PAC0">
+      <name>PAC2</name>
+      <description>Peripheral Access Controller 2</description>
+      <baseAddress>0x42000000</baseAddress>
+    </peripheral>
+    <peripheral>
+      <name>PM</name>
+      <version>2.0.1</version>
+      <description>Power Manager</description>
+      <groupName>PM</groupName>
+      <prependToName>PM_</prependToName>
+      <baseAddress>0x40000400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>PM</name>
+        <value>0</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+        </register>
+        <register>
+          <name>SLEEP</name>
+          <description>Sleep Mode</description>
+          <addressOffset>0x01</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>IDLE</name>
+              <description>Idle Mode Configuration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>IDLESelect</name>
+                <enumeratedValue>
+                  <name>CPU</name>
+                  <description>The CPU clock domain is stopped</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AHB</name>
+                  <description>The CPU and AHB clock domains are stopped</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>APB</name>
+                  <description>The CPU, AHB and APB clock domains are stopped</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CPUSEL</name>
+          <description>CPU Clock Select</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CPUDIV</name>
+              <description>CPU Prescaler Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CPUDIVSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Divide by 1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide by 32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide by 128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBASEL</name>
+          <description>APBA Clock Select</description>
+          <addressOffset>0x09</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>APBADIV</name>
+              <description>APBA Prescaler Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>APBADIVSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Divide by 1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide by 32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide by 128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBBSEL</name>
+          <description>APBB Clock Select</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>APBBDIV</name>
+              <description>APBB Prescaler Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>APBBDIVSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Divide by 1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide by 32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide by 128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBCSEL</name>
+          <description>APBC Clock Select</description>
+          <addressOffset>0x0B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>APBCDIV</name>
+              <description>APBC Prescaler Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>APBCDIVSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Divide by 1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide by 32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide by 128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AHBMASK</name>
+          <description>AHB Mask</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <resetValue>0x0000007F</resetValue>
+          <fields>
+            <field>
+              <name>HPB0_</name>
+              <description>HPB0 AHB Clock Mask</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HPB1_</name>
+              <description>HPB1 AHB Clock Mask</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HPB2_</name>
+              <description>HPB2 AHB Clock Mask</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DSU_</name>
+              <description>DSU AHB Clock Mask</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NVMCTRL_</name>
+              <description>NVMCTRL AHB Clock Mask</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DMAC_</name>
+              <description>DMAC AHB Clock Mask</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>USB_</name>
+              <description>USB AHB Clock Mask</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBAMASK</name>
+          <description>APBA Mask</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <resetValue>0x0000007F</resetValue>
+          <fields>
+            <field>
+              <name>PAC0_</name>
+              <description>PAC0 APB Clock Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PM_</name>
+              <description>PM APB Clock Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYSCTRL_</name>
+              <description>SYSCTRL APB Clock Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GCLK_</name>
+              <description>GCLK APB Clock Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WDT_</name>
+              <description>WDT APB Clock Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RTC_</name>
+              <description>RTC APB Clock Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EIC_</name>
+              <description>EIC APB Clock Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBBMASK</name>
+          <description>APBB Mask</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <resetValue>0x0000007F</resetValue>
+          <fields>
+            <field>
+              <name>PAC1_</name>
+              <description>PAC1 APB Clock Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DSU_</name>
+              <description>DSU APB Clock Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NVMCTRL_</name>
+              <description>NVMCTRL APB Clock Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PORT_</name>
+              <description>PORT APB Clock Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DMAC_</name>
+              <description>DMAC APB Clock Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>USB_</name>
+              <description>USB APB Clock Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HMATRIX_</name>
+              <description>HMATRIX APB Clock Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBCMASK</name>
+          <description>APBC Mask</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <resetValue>0x00010000</resetValue>
+          <fields>
+            <field>
+              <name>PAC2_</name>
+              <description>PAC2 APB Clock Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVSYS_</name>
+              <description>EVSYS APB Clock Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SERCOM0_</name>
+              <description>SERCOM0 APB Clock Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SERCOM1_</name>
+              <description>SERCOM1 APB Clock Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SERCOM2_</name>
+              <description>SERCOM2 APB Clock Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SERCOM3_</name>
+              <description>SERCOM3 APB Clock Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SERCOM4_</name>
+              <description>SERCOM4 APB Clock Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SERCOM5_</name>
+              <description>SERCOM5 APB Clock Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCC0_</name>
+              <description>TCC0 APB Clock Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCC1_</name>
+              <description>TCC1 APB Clock Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCC2_</name>
+              <description>TCC2 APB Clock Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TC3_</name>
+              <description>TC3 APB Clock Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TC4_</name>
+              <description>TC4 APB Clock Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TC5_</name>
+              <description>TC5 APB Clock Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TC6_</name>
+              <description>TC6 APB Clock Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TC7_</name>
+              <description>TC7 APB Clock Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADC_</name>
+              <description>ADC APB Clock Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AC_</name>
+              <description>AC APB Clock Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DAC_</name>
+              <description>DAC APB Clock Enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PTC_</name>
+              <description>PTC APB Clock Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>I2S_</name>
+              <description>I2S APB Clock Enable</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x34</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CKRDY</name>
+              <description>Clock Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x35</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CKRDY</name>
+              <description>Clock Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x36</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CKRDY</name>
+              <description>Clock Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCAUSE</name>
+          <description>Reset Cause</description>
+          <addressOffset>0x38</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x01</resetValue>
+          <fields>
+            <field>
+              <name>POR</name>
+              <description>Power On Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD12</name>
+              <description>Brown Out 12 Detector Reset</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33</name>
+              <description>Brown Out 33 Detector Reset</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXT</name>
+              <description>External Reset</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WDT</name>
+              <description>Watchdog Reset</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYST</name>
+              <description>System Reset Request</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>PORT</name>
+      <version>1.0.0</version>
+      <description>Port Module</description>
+      <groupName>PORT</groupName>
+      <prependToName>PORT_</prependToName>
+      <baseAddress>0x41004400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x200</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>DIR%s</name>
+          <description>Data Direction</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Port Data Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>DIRCLR%s</name>
+          <description>Data Direction Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DIRCLR</name>
+              <description>Port Data Direction Clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>DIRSET%s</name>
+          <description>Data Direction Set</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DIRSET</name>
+              <description>Port Data Direction Set</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>DIRTGL%s</name>
+          <description>Data Direction Toggle</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DIRTGL</name>
+              <description>Port Data Direction Toggle</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>OUT%s</name>
+          <description>Data Output Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OUT</name>
+              <description>Port Data Output Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>OUTCLR%s</name>
+          <description>Data Output Value Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OUTCLR</name>
+              <description>Port Data Output Value Clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>OUTSET%s</name>
+          <description>Data Output Value Set</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OUTSET</name>
+              <description>Port Data Output Value Set</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>OUTTGL%s</name>
+          <description>Data Output Value Toggle</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OUTTGL</name>
+              <description>Port Data Output Value Toggle</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>IN%s</name>
+          <description>Data Input Value</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>IN</name>
+              <description>Port Data Input Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>CTRL%s</name>
+          <description>Control</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SAMPLING</name>
+              <description>Input Sampling Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>WRCONFIG%s</name>
+          <description>Write Configuration</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>PINMASK</name>
+              <description>Pin Mask for Multiple Pin Configuration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+            <field>
+              <name>PMUXEN</name>
+              <description>Peripheral Multiplexer Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INEN</name>
+              <description>Input Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PULLEN</name>
+              <description>Pull Enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRVSTR</name>
+              <description>Output Driver Strength Selection</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PMUX</name>
+              <description>Peripheral Multiplexing</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>WRPMUX</name>
+              <description>Write PMUX</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WRPINCFG</name>
+              <description>Write PINCFG</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HWSEL</name>
+              <description>Half-Word Select</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>16</dim>
+          <dimIncrement>0x1</dimIncrement>
+          <name>PMUX0_%s</name>
+          <description>Peripheral Multiplexing n - Group 0</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PMUXE</name>
+              <description>Peripheral Multiplexing Even</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PMUXESelect</name>
+                <enumeratedValue>
+                  <name>A</name>
+                  <description>Peripheral function A selected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>B</name>
+                  <description>Peripheral function B selected</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>C</name>
+                  <description>Peripheral function C selected</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>D</name>
+                  <description>Peripheral function D selected</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>E</name>
+                  <description>Peripheral function E selected</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>F</name>
+                  <description>Peripheral function F selected</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>G</name>
+                  <description>Peripheral function G selected</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>H</name>
+                  <description>Peripheral function H selected</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PMUXO</name>
+              <description>Peripheral Multiplexing Odd</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PMUXOSelect</name>
+                <enumeratedValue>
+                  <name>A</name>
+                  <description>Peripheral function A selected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>B</name>
+                  <description>Peripheral function B selected</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>C</name>
+                  <description>Peripheral function C selected</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>D</name>
+                  <description>Peripheral function D selected</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>E</name>
+                  <description>Peripheral function E selected</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>F</name>
+                  <description>Peripheral function F selected</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>G</name>
+                  <description>Peripheral function G selected</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>H</name>
+                  <description>Peripheral function H selected</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register derivedFrom="PMUX0_%s">
+          <dim>16</dim>
+          <dimIncrement>0x1</dimIncrement>
+          <name>PMUX1_%s</name>
+          <description>Peripheral Multiplexing n - Group 1</description>
+          <addressOffset>0xb0</addressOffset>
+        </register>
+        <register>
+          <dim>32</dim>
+          <dimIncrement>0x1</dimIncrement>
+          <name>PINCFG0_%s</name>
+          <description>Pin Configuration n - Group 0</description>
+          <addressOffset>0x40</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PMUXEN</name>
+              <description>Peripheral Multiplexer Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INEN</name>
+              <description>Input Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PULLEN</name>
+              <description>Pull Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRVSTR</name>
+              <description>Output Driver Strength Selection</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register derivedFrom="PINCFG0_%s">
+          <dim>32</dim>
+          <dimIncrement>0x1</dimIncrement>
+          <name>PINCFG1_%s</name>
+          <description>Pin Configuration n - Group 1</description>
+          <addressOffset>0xc0</addressOffset>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="PORT">
+      <name>PORT_IOBUS</name>
+      <description>Port Module (IOBUS)</description>
+      <groupName>PORT_IOBUS</groupName>
+      <prependToName>PORT_IOBUS_</prependToName>
+      <baseAddress>0x60000000</baseAddress>
+    </peripheral>
+    <peripheral>
+      <name>RTC</name>
+      <version>1.0.1</version>
+      <description>Real-Time Counter</description>
+      <groupName>RTC</groupName>
+      <prependToName>RTC_</prependToName>
+      <baseAddress>0x40001400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>RTC</name>
+        <value>3</value>
+      </interrupt>
+      <registers>
+       <cluster>
+        <name>MODE0</name>
+        <description>32-bit Counter with Single 32-bit Compare</description>
+        <headerStructName>RtcMode0</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRL</name>
+          <description>MODE0 Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Mode 0: 32-bit Counter</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Mode 1: 16-bit Counter</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLOCK</name>
+                  <description>Mode 2: Clock/Calendar</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MATCHCLR</name>
+              <description>Clear on Match</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/256</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/512</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1024</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <resetValue>0x0010</resetValue>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>MODE0 Event Control</description>
+          <addressOffset>0x04</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PEREO0</name>
+              <description>Periodic Interval 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO1</name>
+              <description>Periodic Interval 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO2</name>
+              <description>Periodic Interval 2 Event Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO3</name>
+              <description>Periodic Interval 3 Event Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO4</name>
+              <description>Periodic Interval 4 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO5</name>
+              <description>Periodic Interval 5 Event Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO6</name>
+              <description>Periodic Interval 6 Event Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO7</name>
+              <description>Periodic Interval 7 Event Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMPEO0</name>
+              <description>Compare 0 Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow Event Output Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>MODE0 Interrupt Enable Clear</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>MODE0 Interrupt Enable Set</description>
+          <addressOffset>0x07</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>MODE0 Interrupt Flag Status and Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x0B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Run During Debug</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FREQCORR</name>
+          <description>Frequency Correction</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>VALUE</name>
+              <description>Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+            <field>
+              <name>SIGN</name>
+              <description>Correction Sign</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>MODE0 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>COMP%s</name>
+          <description>MODE0 Compare n Value</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COMP</name>
+              <description>Compare Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- RtcMode0 -->
+       <cluster>
+        <name>MODE1</name>
+        <description>16-bit Counter with Two 16-bit Compares</description>
+        <alternateCluster>MODE0</alternateCluster>
+        <headerStructName>RtcMode1</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRL</name>
+          <description>MODE1 Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Mode 0: 32-bit Counter</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Mode 1: 16-bit Counter</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLOCK</name>
+                  <description>Mode 2: Clock/Calendar</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/256</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/512</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1024</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <resetValue>0x0010</resetValue>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>MODE1 Event Control</description>
+          <addressOffset>0x04</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PEREO0</name>
+              <description>Periodic Interval 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO1</name>
+              <description>Periodic Interval 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO2</name>
+              <description>Periodic Interval 2 Event Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO3</name>
+              <description>Periodic Interval 3 Event Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO4</name>
+              <description>Periodic Interval 4 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO5</name>
+              <description>Periodic Interval 5 Event Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO6</name>
+              <description>Periodic Interval 6 Event Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO7</name>
+              <description>Periodic Interval 7 Event Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMPEO0</name>
+              <description>Compare 0 Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMPEO1</name>
+              <description>Compare 1 Event Output Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow Event Output Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>MODE1 Interrupt Enable Clear</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMP1</name>
+              <description>Compare 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>MODE1 Interrupt Enable Set</description>
+          <addressOffset>0x07</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMP1</name>
+              <description>Compare 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>MODE1 Interrupt Flag Status and Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMP1</name>
+              <description>Compare 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x0B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Run During Debug</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FREQCORR</name>
+          <description>Frequency Correction</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>VALUE</name>
+              <description>Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+            <field>
+              <name>SIGN</name>
+              <description>Correction Sign</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>MODE1 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER</name>
+          <description>MODE1 Counter Period</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PER</name>
+              <description>Counter Period</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x2</dimIncrement>
+          <name>COMP%s</name>
+          <description>MODE1 Compare n Value</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>COMP</name>
+              <description>Compare Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- RtcMode1 -->
+       <cluster>
+        <name>MODE2</name>
+        <description>Clock/Calendar with Alarm</description>
+        <alternateCluster>MODE0</alternateCluster>
+        <headerStructName>RtcMode2</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRL</name>
+          <description>MODE2 Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Mode 0: 32-bit Counter</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Mode 1: 16-bit Counter</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLOCK</name>
+                  <description>Mode 2: Clock/Calendar</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CLKREP</name>
+              <description>Clock Representation</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MATCHCLR</name>
+              <description>Clear on Match</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/256</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/512</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1024</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <resetValue>0x0010</resetValue>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>MODE2 Event Control</description>
+          <addressOffset>0x04</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PEREO0</name>
+              <description>Periodic Interval 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO1</name>
+              <description>Periodic Interval 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO2</name>
+              <description>Periodic Interval 2 Event Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO3</name>
+              <description>Periodic Interval 3 Event Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO4</name>
+              <description>Periodic Interval 4 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO5</name>
+              <description>Periodic Interval 5 Event Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO6</name>
+              <description>Periodic Interval 6 Event Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO7</name>
+              <description>Periodic Interval 7 Event Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ALARMEO0</name>
+              <description>Alarm 0 Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow Event Output Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>MODE2 Interrupt Enable Clear</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ALARM0</name>
+              <description>Alarm 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>MODE2 Interrupt Enable Set</description>
+          <addressOffset>0x07</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ALARM0</name>
+              <description>Alarm 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>MODE2 Interrupt Flag Status and Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ALARM0</name>
+              <description>Alarm 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x0B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Run During Debug</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FREQCORR</name>
+          <description>Frequency Correction</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>VALUE</name>
+              <description>Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+            <field>
+              <name>SIGN</name>
+              <description>Correction Sign</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CLOCK</name>
+          <description>MODE2 Clock Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SECOND</name>
+              <description>Second</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>MINUTE</name>
+              <description>Minute</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>HOUR</name>
+              <description>Hour</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>HOURSelect</name>
+                <enumeratedValue>
+                  <name>AM</name>
+                  <description>AM when CLKREP in 12-hour</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PM</name>
+                  <description>PM when CLKREP in 12-hour</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>DAY</name>
+              <description>Day</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>MONTH</name>
+              <description>Month</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>YEAR</name>
+              <description>Year</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x8</dimIncrement>
+          <name>ALARM%s</name>
+          <description>MODE2 Alarm n Value</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SECOND</name>
+              <description>Second</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>MINUTE</name>
+              <description>Minute</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>HOUR</name>
+              <description>Hour</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>HOURSelect</name>
+                <enumeratedValue>
+                  <name>AM</name>
+                  <description>Morning hour</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PM</name>
+                  <description>Afternoon hour</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>DAY</name>
+              <description>Day</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>MONTH</name>
+              <description>Month</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>YEAR</name>
+              <description>Year</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x8</dimIncrement>
+          <name>MASK%s</name>
+          <description>MODE2 Alarm n Mask</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SEL</name>
+              <description>Alarm Mask Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SELSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Alarm Disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SS</name>
+                  <description>Match seconds only</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MMSS</name>
+                  <description>Match seconds and minutes only</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HHMMSS</name>
+                  <description>Match seconds, minutes, and hours only</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DDHHMMSS</name>
+                  <description>Match seconds, minutes, hours, and days only</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MMDDHHMMSS</name>
+                  <description>Match seconds, minutes, hours, days, and months only</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>YYMMDDHHMMSS</name>
+                  <description>Match seconds, minutes, hours, days, months, and years</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- RtcMode2 -->
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>SERCOM0</name>
+      <version>2.0.0</version>
+      <description>Serial Communication Interface 0</description>
+      <groupName>SERCOM</groupName>
+      <prependToName>SERCOM_</prependToName>
+      <baseAddress>0x42000800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>SERCOM0</name>
+        <value>9</value>
+      </interrupt>
+      <registers>
+       <cluster>
+        <name>I2CM</name>
+        <description>I2C Master Mode</description>
+        <headerStructName>SercomI2cm</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>I2CM Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>USART_EXT_CLK</name>
+                  <description>USART mode with external clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USART_INT_CLK</name>
+                  <description>USART mode with internal clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_SLAVE</name>
+                  <description>SPI mode with external clock</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_MASTER</name>
+                  <description>SPI mode with internal clock</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_SLAVE</name>
+                  <description>I2C mode with external clock</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MASTER</name>
+                  <description>I2C mode with internal clock</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PINOUT</name>
+              <description>Pin Usage</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SDAHOLD</name>
+              <description>SDA Hold Time</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MEXTTOEN</name>
+              <description>Master SCL Low Extend Timeout</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SEXTTOEN</name>
+              <description>Slave SCL Low Extend Timeout</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPEED</name>
+              <description>Transfer Speed</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>SCLSM</name>
+              <description>SCL Clock Stretch Mode</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INACTOUT</name>
+              <description>Inactive Time-Out</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>LOWTOUTEN</name>
+              <description>SCL Low Timeout Enable</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>I2CM Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SMEN</name>
+              <description>Smart Mode Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>QCEN</name>
+              <description>Quick Command Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ACKACT</name>
+              <description>Acknowledge Action</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD</name>
+          <description>I2CM Baud Rate</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>BAUDLOW</name>
+              <description>Baud Rate Value Low</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>HSBAUD</name>
+              <description>High Speed Baud Rate Value</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>HSBAUDLOW</name>
+              <description>High Speed Baud Rate Value Low</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>I2CM Interrupt Enable Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>MB</name>
+              <description>Master On Bus Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SB</name>
+              <description>Slave On Bus Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>I2CM Interrupt Enable Set</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>MB</name>
+              <description>Master On Bus Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SB</name>
+              <description>Slave On Bus Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>I2CM Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>MB</name>
+              <description>Master On Bus Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SB</name>
+              <description>Slave On Bus Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>I2CM Status</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BUSERR</name>
+              <description>Bus Error</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ARBLOST</name>
+              <description>Arbitration Lost</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXNACK</name>
+              <description>Received Not Acknowledge</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSSTATE</name>
+              <description>Bus State</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>LOWTOUT</name>
+              <description>SCL Low Timeout</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CLKHOLD</name>
+              <description>Clock Hold</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>MEXTTOUT</name>
+              <description>Master SCL Low Extend Timeout</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SEXTTOUT</name>
+              <description>Slave SCL Low Extend Timeout</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LENERR</name>
+              <description>Length Error</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>I2CM Syncbusy</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>SERCOM Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYSOP</name>
+              <description>System Operation Synchronization Busy</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>I2CM Address</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>11</bitWidth>
+            </field>
+            <field>
+              <name>LENEN</name>
+              <description>Length Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HS</name>
+              <description>High Speed Mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TENBITEN</name>
+              <description>Ten Bit Addressing Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LEN</name>
+              <description>Length</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>I2CM Data</description>
+          <addressOffset>0x28</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>I2CM Debug Control</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGSTOP</name>
+              <description>Debug Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- SercomI2cm -->
+       <cluster>
+        <name>I2CS</name>
+        <description>I2C Slave Mode</description>
+        <alternateCluster>I2CM</alternateCluster>
+        <headerStructName>SercomI2cs</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>I2CS Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>USART_EXT_CLK</name>
+                  <description>USART mode with external clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USART_INT_CLK</name>
+                  <description>USART mode with internal clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_SLAVE</name>
+                  <description>SPI mode with external clock</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_MASTER</name>
+                  <description>SPI mode with internal clock</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_SLAVE</name>
+                  <description>I2C mode with external clock</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MASTER</name>
+                  <description>I2C mode with internal clock</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run during Standby</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PINOUT</name>
+              <description>Pin Usage</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SDAHOLD</name>
+              <description>SDA Hold Time</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>SEXTTOEN</name>
+              <description>Slave SCL Low Extend Timeout</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPEED</name>
+              <description>Transfer Speed</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>SCLSM</name>
+              <description>SCL Clock Stretch Mode</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LOWTOUTEN</name>
+              <description>SCL Low Timeout Enable</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>I2CS Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SMEN</name>
+              <description>Smart Mode Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GCMD</name>
+              <description>PMBus Group Command</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AACKEN</name>
+              <description>Automatic Address Acknowledge</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMODE</name>
+              <description>Address Mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ACKACT</name>
+              <description>Acknowledge Action</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>I2CS Interrupt Enable Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PREC</name>
+              <description>Stop Received Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMATCH</name>
+              <description>Address Match Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRDY</name>
+              <description>Data Interrupt Disable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>I2CS Interrupt Enable Set</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PREC</name>
+              <description>Stop Received Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMATCH</name>
+              <description>Address Match Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRDY</name>
+              <description>Data Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>I2CS Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PREC</name>
+              <description>Stop Received Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMATCH</name>
+              <description>Address Match Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRDY</name>
+              <description>Data Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>I2CS Status</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BUSERR</name>
+              <description>Bus Error</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COLL</name>
+              <description>Transmit Collision</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXNACK</name>
+              <description>Received Not Acknowledge</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DIR</name>
+              <description>Read/Write Direction</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SR</name>
+              <description>Repeated Start</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LOWTOUT</name>
+              <description>SCL Low Timeout</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CLKHOLD</name>
+              <description>Clock Hold</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SEXTTOUT</name>
+              <description>Slave SCL Low Extend Timeout</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HS</name>
+              <description>High Speed</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>I2CS Syncbusy</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>SERCOM Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>I2CS Address</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>GENCEN</name>
+              <description>General Call Address Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADDR</name>
+              <description>Address Value</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>10</bitWidth>
+            </field>
+            <field>
+              <name>TENBITEN</name>
+              <description>Ten Bit Addressing Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADDRMASK</name>
+              <description>Address Mask</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>10</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>I2CS Data</description>
+          <addressOffset>0x28</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- SercomI2cs -->
+       <cluster>
+        <name>SPI</name>
+        <description>SPI Mode</description>
+        <alternateCluster>I2CM</alternateCluster>
+        <headerStructName>SercomSpi</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>SPI Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>USART_EXT_CLK</name>
+                  <description>USART mode with external clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USART_INT_CLK</name>
+                  <description>USART mode with internal clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_SLAVE</name>
+                  <description>SPI mode with external clock</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_MASTER</name>
+                  <description>SPI mode with internal clock</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_SLAVE</name>
+                  <description>I2C mode with external clock</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MASTER</name>
+                  <description>I2C mode with internal clock</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run during Standby</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IBON</name>
+              <description>Immediate Buffer Overflow Notification</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DOPO</name>
+              <description>Data Out Pinout</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>DIPO</name>
+              <description>Data In Pinout</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>FORM</name>
+              <description>Frame Format</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>CPHA</name>
+              <description>Clock Phase</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPOL</name>
+              <description>Clock Polarity</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DORD</name>
+              <description>Data Order</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>SPI Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CHSIZE</name>
+              <description>Character Size</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>PLOADEN</name>
+              <description>Data Preload Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SSDE</name>
+              <description>Slave Select Low Detect Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MSSEN</name>
+              <description>Master Slave Select Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMODE</name>
+              <description>Address Mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>RXEN</name>
+              <description>Receiver Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD</name>
+          <description>SPI Baud Rate</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>SPI Interrupt Enable Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt Disable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SSL</name>
+              <description>Slave Select Low Interrupt Disable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>SPI Interrupt Enable Set</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SSL</name>
+              <description>Slave Select Low Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>SPI Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SSL</name>
+              <description>Slave Select Low Interrupt Flag</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>SPI Status</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BUFOVF</name>
+              <description>Buffer Overflow</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>SPI Syncbusy</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>SERCOM Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CTRLB</name>
+              <description>CTRLB Synchronization Busy</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>SPI Address</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>ADDRMASK</name>
+              <description>Address Mask</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>SPI Data</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>SPI Debug Control</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGSTOP</name>
+              <description>Debug Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- SercomSpi -->
+       <cluster>
+        <name>USART</name>
+        <description>USART Mode</description>
+        <alternateCluster>I2CM</alternateCluster>
+        <headerStructName>SercomUsart</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>USART Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>USART_EXT_CLK</name>
+                  <description>USART mode with external clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USART_INT_CLK</name>
+                  <description>USART mode with internal clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_SLAVE</name>
+                  <description>SPI mode with external clock</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_MASTER</name>
+                  <description>SPI mode with internal clock</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_SLAVE</name>
+                  <description>I2C mode with external clock</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MASTER</name>
+                  <description>I2C mode with internal clock</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run during Standby</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IBON</name>
+              <description>Immediate Buffer Overflow Notification</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SAMPR</name>
+              <description>Sample</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>TXPO</name>
+              <description>Transmit Data Pinout</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>RXPO</name>
+              <description>Receive Data Pinout</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>SAMPA</name>
+              <description>Sample Adjustment</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>FORM</name>
+              <description>Frame Format</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>CMODE</name>
+              <description>Communication Mode</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPOL</name>
+              <description>Clock Polarity</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DORD</name>
+              <description>Data Order</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>USART Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CHSIZE</name>
+              <description>Character Size</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SBMODE</name>
+              <description>Stop Bit Mode</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COLDEN</name>
+              <description>Collision Detection Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SFDE</name>
+              <description>Start of Frame Detection Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENC</name>
+              <description>Encoding Format</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PMODE</name>
+              <description>Parity Mode</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXEN</name>
+              <description>Transmitter Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXEN</name>
+              <description>Receiver Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD</name>
+          <description>USART Baud Rate</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD_FRAC_MODE</name>
+          <description>USART Baud Rate</description>
+          <alternateRegister>BAUD</alternateRegister>
+          <addressOffset>0x0C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>13</bitWidth>
+            </field>
+            <field>
+              <name>FP</name>
+              <description>Fractional Part</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD_FRACFP_MODE</name>
+          <description>USART Baud Rate</description>
+          <alternateRegister>BAUD</alternateRegister>
+          <addressOffset>0x0C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>13</bitWidth>
+            </field>
+            <field>
+              <name>FP</name>
+              <description>Fractional Part</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD_USARTFP_MODE</name>
+          <description>USART Baud Rate</description>
+          <alternateRegister>BAUD</alternateRegister>
+          <addressOffset>0x0C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXPL</name>
+          <description>USART Receive Pulse Length</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>RXPL</name>
+              <description>Receive Pulse Length</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>USART Interrupt Enable Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt Disable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXS</name>
+              <description>Receive Start Interrupt Disable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTSIC</name>
+              <description>Clear To Send Input Change Interrupt Disable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXBRK</name>
+              <description>Break Received Interrupt Disable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>USART Interrupt Enable Set</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXS</name>
+              <description>Receive Start Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTSIC</name>
+              <description>Clear To Send Input Change Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXBRK</name>
+              <description>Break Received Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>USART Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RXS</name>
+              <description>Receive Start Interrupt</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CTSIC</name>
+              <description>Clear To Send Input Change Interrupt</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXBRK</name>
+              <description>Break Received Interrupt</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>USART Status</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PERR</name>
+              <description>Parity Error</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FERR</name>
+              <description>Frame Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BUFOVF</name>
+              <description>Buffer Overflow</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTS</name>
+              <description>Clear To Send</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ISF</name>
+              <description>Inconsistent Sync Field</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COLL</name>
+              <description>Collision Detected</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>USART Syncbusy</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>SERCOM Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CTRLB</name>
+              <description>CTRLB Synchronization Busy</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>USART Data</description>
+          <addressOffset>0x28</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>USART Debug Control</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGSTOP</name>
+              <description>Debug Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- SercomUsart -->
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="SERCOM0">
+      <name>SERCOM1</name>
+      <description>Serial Communication Interface 1</description>
+      <baseAddress>0x42000C00</baseAddress>
+      <interrupt>
+        <name>SERCOM1</name>
+        <value>10</value>
+      </interrupt>
+    </peripheral>
+    <peripheral derivedFrom="SERCOM0">
+      <name>SERCOM2</name>
+      <description>Serial Communication Interface 2</description>
+      <baseAddress>0x42001000</baseAddress>
+      <interrupt>
+        <name>SERCOM2</name>
+        <value>11</value>
+      </interrupt>
+    </peripheral>
+    <peripheral derivedFrom="SERCOM0">
+      <name>SERCOM3</name>
+      <description>Serial Communication Interface 3</description>
+      <baseAddress>0x42001400</baseAddress>
+      <interrupt>
+        <name>SERCOM3</name>
+        <value>12</value>
+      </interrupt>
+    </peripheral>
+    <peripheral derivedFrom="SERCOM0">
+      <name>SERCOM4</name>
+      <description>Serial Communication Interface 4</description>
+      <baseAddress>0x42001800</baseAddress>
+      <interrupt>
+        <name>SERCOM4</name>
+        <value>13</value>
+      </interrupt>
+    </peripheral>
+    <peripheral derivedFrom="SERCOM0">
+      <name>SERCOM5</name>
+      <description>Serial Communication Interface 5</description>
+      <baseAddress>0x42001C00</baseAddress>
+      <interrupt>
+        <name>SERCOM5</name>
+        <value>14</value>
+      </interrupt>
+    </peripheral>
+    <peripheral>
+      <name>SYSCTRL</name>
+      <version>2.0.1</version>
+      <description>System Control</description>
+      <groupName>SYSCTRL</groupName>
+      <prependToName>SYSCTRL_</prependToName>
+      <baseAddress>0x40000800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>SYSCTRL</name>
+        <value>1</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>XOSCRDY</name>
+              <description>XOSC Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XOSC32KRDY</name>
+              <description>XOSC32K Ready Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC32KRDY</name>
+              <description>OSC32K Ready Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC8MRDY</name>
+              <description>OSC8M Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRDY</name>
+              <description>DFLL Ready Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLOOB</name>
+              <description>DFLL Out Of Bounds Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKF</name>
+              <description>DFLL Lock Fine Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKC</name>
+              <description>DFLL Lock Coarse Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRCS</name>
+              <description>DFLL Reference Clock Stopped Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33RDY</name>
+              <description>BOD33 Ready Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33DET</name>
+              <description>BOD33 Detection Interrupt Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>B33SRDY</name>
+              <description>BOD33 Synchronization Ready Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKR</name>
+              <description>DPLL Lock Rise Interrupt Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKF</name>
+              <description>DPLL Lock Fall Interrupt Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLTO</name>
+              <description>DPLL Lock Timeout Interrupt Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>XOSCRDY</name>
+              <description>XOSC Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XOSC32KRDY</name>
+              <description>XOSC32K Ready Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC32KRDY</name>
+              <description>OSC32K Ready Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC8MRDY</name>
+              <description>OSC8M Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRDY</name>
+              <description>DFLL Ready Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLOOB</name>
+              <description>DFLL Out Of Bounds Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKF</name>
+              <description>DFLL Lock Fine Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKC</name>
+              <description>DFLL Lock Coarse Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRCS</name>
+              <description>DFLL Reference Clock Stopped Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33RDY</name>
+              <description>BOD33 Ready Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33DET</name>
+              <description>BOD33 Detection Interrupt Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>B33SRDY</name>
+              <description>BOD33 Synchronization Ready Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKR</name>
+              <description>DPLL Lock Rise Interrupt Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKF</name>
+              <description>DPLL Lock Fall Interrupt Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLTO</name>
+              <description>DPLL Lock Timeout Interrupt Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>XOSCRDY</name>
+              <description>XOSC Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XOSC32KRDY</name>
+              <description>XOSC32K Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC32KRDY</name>
+              <description>OSC32K Ready</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC8MRDY</name>
+              <description>OSC8M Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRDY</name>
+              <description>DFLL Ready</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLOOB</name>
+              <description>DFLL Out Of Bounds</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKF</name>
+              <description>DFLL Lock Fine</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKC</name>
+              <description>DFLL Lock Coarse</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRCS</name>
+              <description>DFLL Reference Clock Stopped</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33RDY</name>
+              <description>BOD33 Ready</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33DET</name>
+              <description>BOD33 Detection</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>B33SRDY</name>
+              <description>BOD33 Synchronization Ready</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKR</name>
+              <description>DPLL Lock Rise</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKF</name>
+              <description>DPLL Lock Fall</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLTO</name>
+              <description>DPLL Lock Timeout</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PCLKSR</name>
+          <description>Power and Clocks Status</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>XOSCRDY</name>
+              <description>XOSC Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>XOSC32KRDY</name>
+              <description>XOSC32K Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>OSC32KRDY</name>
+              <description>OSC32K Ready</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>OSC8MRDY</name>
+              <description>OSC8M Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLRDY</name>
+              <description>DFLL Ready</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLOOB</name>
+              <description>DFLL Out Of Bounds</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLLCKF</name>
+              <description>DFLL Lock Fine</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLLCKC</name>
+              <description>DFLL Lock Coarse</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLRCS</name>
+              <description>DFLL Reference Clock Stopped</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BOD33RDY</name>
+              <description>BOD33 Ready</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BOD33DET</name>
+              <description>BOD33 Detection</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>B33SRDY</name>
+              <description>BOD33 Synchronization Ready</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DPLLLCKR</name>
+              <description>DPLL Lock Rise</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DPLLLCKF</name>
+              <description>DPLL Lock Fall</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DPLLLTO</name>
+              <description>DPLL Lock Timeout</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>XOSC</name>
+          <description>External Multipurpose Crystal Oscillator (XOSC) Control</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <resetValue>0x0080</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Oscillator Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XTALEN</name>
+              <description>Crystal Oscillator Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GAIN</name>
+              <description>Oscillator Gain</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>GAINSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>2MHz</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>4MHz</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>8MHz</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>3</name>
+                  <description>16MHz</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4</name>
+                  <description>30MHz</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>AMPGC</name>
+              <description>Automatic Amplitude Gain Control</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STARTUP</name>
+              <description>Start-Up Time</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>XOSC32K</name>
+          <description>32kHz External Crystal Oscillator (XOSC32K) Control</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <resetValue>0x0080</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Oscillator Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XTALEN</name>
+              <description>Crystal Oscillator Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN32K</name>
+              <description>32kHz Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN1K</name>
+              <description>1kHz Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AAMPEN</name>
+              <description>Automatic Amplitude Control Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STARTUP</name>
+              <description>Oscillator Start-Up Time</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>WRTLOCK</name>
+              <description>Write Lock</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSC32K</name>
+          <description>32kHz Internal Oscillator (OSC32K) Control</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <resetValue>0x003F0080</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Oscillator Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN32K</name>
+              <description>32kHz Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN1K</name>
+              <description>1kHz Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STARTUP</name>
+              <description>Oscillator Start-Up Time</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>WRTLOCK</name>
+              <description>Write Lock</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CALIB</name>
+              <description>Oscillator Calibration</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSCULP32K</name>
+          <description>32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>8</size>
+          <resetValue>0x1F</resetValue>
+          <fields>
+            <field>
+              <name>CALIB</name>
+              <description>Oscillator Calibration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>WRTLOCK</name>
+              <description>Write Lock</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSC8M</name>
+          <description>8MHz Internal Oscillator (OSC8M) Control</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <resetValue>0x87070382</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Oscillator Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESC</name>
+              <description>Oscillator Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>3</name>
+                  <description>8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CALIB</name>
+              <description>Oscillator Calibration</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+            <field>
+              <name>FRANGE</name>
+              <description>Oscillator Frequency Range</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>FRANGESelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>4 to 6MHz</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>6 to 8MHz</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>8 to 11MHz</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>3</name>
+                  <description>11 to 15MHz</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DFLLCTRL</name>
+          <description>DFLL48M Control</description>
+          <addressOffset>0x24</addressOffset>
+          <size>16</size>
+          <resetValue>0x0080</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>DFLL Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode Selection</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STABLE</name>
+              <description>Stable DFLL Frequency</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LLAW</name>
+              <description>Lose Lock After Wake</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>USBCRM</name>
+              <description>USB Clock Recovery Mode</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCDIS</name>
+              <description>Chill Cycle Disable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>QLDIS</name>
+              <description>Quick Lock Disable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BPLCKC</name>
+              <description>Bypass Coarse Lock</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAITLOCK</name>
+              <description>Wait Lock</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DFLLVAL</name>
+          <description>DFLL48M Value</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>FINE</name>
+              <description>Fine Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>10</bitWidth>
+            </field>
+            <field>
+              <name>COARSE</name>
+              <description>Coarse Value</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>DIFF</name>
+              <description>Multiplication Ratio Difference</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DFLLMUL</name>
+          <description>DFLL48M Multiplier</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>MUL</name>
+              <description>DFLL Multiply Factor</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+            <field>
+              <name>FSTEP</name>
+              <description>Fine Maximum Step</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>10</bitWidth>
+            </field>
+            <field>
+              <name>CSTEP</name>
+              <description>Coarse Maximum Step</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DFLLSYNC</name>
+          <description>DFLL48M Synchronization</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>READREQ</name>
+              <description>Read Request</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BOD33</name>
+          <description>3.3V Brown-Out Detector (BOD33) Control</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HYST</name>
+              <description>Hysteresis</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ACTION</name>
+              <description>BOD33 Action</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>ACTIONSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESET</name>
+                  <description>The BOD33 generates a reset</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INTERRUPT</name>
+                  <description>The BOD33 generates an interrupt</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operation Mode</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CEN</name>
+              <description>Clock Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PSEL</name>
+              <description>Prescaler Select</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PSELSelect</name>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide clock by 2</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide clock by 4</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide clock by 8</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide clock by 16</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide clock by 32</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide clock by 64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide clock by 128</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Divide clock by 256</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>Divide clock by 512</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1K</name>
+                  <description>Divide clock by 1024</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2K</name>
+                  <description>Divide clock by 2048</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4K</name>
+                  <description>Divide clock by 4096</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8K</name>
+                  <description>Divide clock by 8192</description>
+                  <value>0xc</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16K</name>
+                  <description>Divide clock by 16384</description>
+                  <value>0xd</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32K</name>
+                  <description>Divide clock by 32768</description>
+                  <value>0xe</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64K</name>
+                  <description>Divide clock by 65536</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LEVEL</name>
+              <description>BOD33 Threshold Level</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>VREG</name>
+          <description>Voltage Regulator System (VREG) Control</description>
+          <addressOffset>0x3C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FORCELDO</name>
+              <description>Force LDO Voltage Regulator</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>VREF</name>
+          <description>Voltage References System (VREF) Control</description>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>TSEN</name>
+              <description>Temperature Sensor Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BGOUTEN</name>
+              <description>Bandgap Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CALIB</name>
+              <description>Bandgap Voltage Generator Calibration</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>11</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DPLLCTRLA</name>
+          <description>DPLL Control A</description>
+          <addressOffset>0x44</addressOffset>
+          <size>8</size>
+          <resetValue>0x80</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>DPLL Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Clock Activation</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DPLLRATIO</name>
+          <description>DPLL Ratio Control</description>
+          <addressOffset>0x48</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>LDR</name>
+              <description>Loop Divider Ratio</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+            <field>
+              <name>LDRFRAC</name>
+              <description>Loop Divider Ratio Fractional Part</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DPLLCTRLB</name>
+          <description>DPLL Control B</description>
+          <addressOffset>0x4C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>FILTER</name>
+              <description>Proportional Integral Filter Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>FILTERSelect</name>
+                <enumeratedValue>
+                  <name>DEFAULT</name>
+                  <description>Default filter mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LBFILT</name>
+                  <description>Low bandwidth filter</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HBFILT</name>
+                  <description>High bandwidth filter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HDFILT</name>
+                  <description>High damping filter</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LPEN</name>
+              <description>Low-Power Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WUF</name>
+              <description>Wake Up Fast</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>REFCLK</name>
+              <description>Reference Clock Selection</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>REFCLKSelect</name>
+                <enumeratedValue>
+                  <name>REF0</name>
+                  <description>CLK_DPLL_REF0 clock reference</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>REF1</name>
+                  <description>CLK_DPLL_REF1 clock reference</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>GCLK_DPLL clock reference</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LTIME</name>
+              <description>Lock Time</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>LTIMESelect</name>
+                <enumeratedValue>
+                  <name>DEFAULT</name>
+                  <description>No time-out</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8MS</name>
+                  <description>Time-out if no lock within 8 ms</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>9MS</name>
+                  <description>Time-out if no lock within 9 ms</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>10MS</name>
+                  <description>Time-out if no lock within 10 ms</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>11MS</name>
+                  <description>Time-out if no lock within 11 ms</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LBYPASS</name>
+              <description>Lock Bypass</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DIV</name>
+              <description>Clock Divider</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>11</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DPLLSTATUS</name>
+          <description>DPLL Status</description>
+          <addressOffset>0x50</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>LOCK</name>
+              <description>DPLL Lock Status</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CLKRDY</name>
+              <description>Output Clock Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>DPLL Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DIV</name>
+              <description>Divider Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>TC3</name>
+      <version>1.2.1</version>
+      <description>Basic Timer Counter 3</description>
+      <groupName>TC</groupName>
+      <prependToName>TC_</prependToName>
+      <baseAddress>0x42002C00</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x040</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>TC3</name>
+        <value>18</value>
+      </interrupt>
+      <registers>
+       <cluster>
+        <name>COUNT8</name>
+        <description>8-bit Counter Mode</description>
+        <headerStructName>TcCount8</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>TC Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Counter in 16-bit mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT8</name>
+                  <description>Counter in 8-bit mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Counter in 32-bit mode</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>WAVEGEN</name>
+              <description>Waveform Generation Operation</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MPWM</name>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Prescaler: GCLK_TC</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Prescaler: GCLK_TC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Prescaler: GCLK_TC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Prescaler: GCLK_TC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Prescaler: GCLK_TC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Prescaler: GCLK_TC/64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Prescaler: GCLK_TC/256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>Prescaler: GCLK_TC/1024</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCSYNC</name>
+              <description>Prescaler and Counter Synchronization</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSYNCSelect</name>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>Reload or reset the counter on next generic clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PRESC</name>
+                  <description>Reload or reset the counter on next prescaler clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNC</name>
+                  <description>Reload or reset the counter on next generic clock. Reset the prescaler counter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBCLR</name>
+          <description>Control B Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <resetValue>0x02</resetValue>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBSET</name>
+          <description>Control B Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLC</name>
+          <description>Control C</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>INVEN0</name>
+              <description>Output Waveform 0 Invert Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN1</name>
+              <description>Output Waveform 1 Invert Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN0</name>
+              <description>Capture Channel 0 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN1</name>
+              <description>Capture Channel 1 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>EVACT</name>
+              <description>Event Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACTSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Start, restart or retrigger TC on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT</name>
+                  <description>Count on event</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Start TC on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PPW</name>
+                  <description>Period captured in CC0, pulse width in CC1</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWP</name>
+                  <description>Period captured in CC1, pulse width in CC0</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TCINV</name>
+              <description>TC Inverted Event Input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI</name>
+              <description>TC Event Input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow/Underflow Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO0</name>
+              <description>Match or Capture Channel 0 Event Output Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO1</name>
+              <description>Match or Capture Channel 1 Event Output Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x0D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0F</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x08</resetValue>
+          <fields>
+            <field>
+              <name>STOP</name>
+              <description>Stop</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SLAVE</name>
+              <description>Slave</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>COUNT8 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER</name>
+          <description>COUNT8 Period Value</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <resetValue>0xFF</resetValue>
+          <fields>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x1</dimIncrement>
+          <name>CC%s</name>
+          <description>COUNT8 Compare/Capture</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CC</name>
+              <description>Compare/Capture Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- TcCount8 -->
+       <cluster>
+        <name>COUNT16</name>
+        <description>16-bit Counter Mode</description>
+        <alternateCluster>COUNT8</alternateCluster>
+        <headerStructName>TcCount16</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>TC Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Counter in 16-bit mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT8</name>
+                  <description>Counter in 8-bit mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Counter in 32-bit mode</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>WAVEGEN</name>
+              <description>Waveform Generation Operation</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MPWM</name>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Prescaler: GCLK_TC</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Prescaler: GCLK_TC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Prescaler: GCLK_TC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Prescaler: GCLK_TC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Prescaler: GCLK_TC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Prescaler: GCLK_TC/64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Prescaler: GCLK_TC/256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>Prescaler: GCLK_TC/1024</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCSYNC</name>
+              <description>Prescaler and Counter Synchronization</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSYNCSelect</name>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>Reload or reset the counter on next generic clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PRESC</name>
+                  <description>Reload or reset the counter on next prescaler clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNC</name>
+                  <description>Reload or reset the counter on next generic clock. Reset the prescaler counter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBCLR</name>
+          <description>Control B Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <resetValue>0x02</resetValue>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBSET</name>
+          <description>Control B Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLC</name>
+          <description>Control C</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>INVEN0</name>
+              <description>Output Waveform 0 Invert Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN1</name>
+              <description>Output Waveform 1 Invert Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN0</name>
+              <description>Capture Channel 0 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN1</name>
+              <description>Capture Channel 1 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>EVACT</name>
+              <description>Event Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACTSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Start, restart or retrigger TC on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT</name>
+                  <description>Count on event</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Start TC on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PPW</name>
+                  <description>Period captured in CC0, pulse width in CC1</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWP</name>
+                  <description>Period captured in CC1, pulse width in CC0</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TCINV</name>
+              <description>TC Inverted Event Input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI</name>
+              <description>TC Event Input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow/Underflow Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO0</name>
+              <description>Match or Capture Channel 0 Event Output Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO1</name>
+              <description>Match or Capture Channel 1 Event Output Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x0D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0F</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x08</resetValue>
+          <fields>
+            <field>
+              <name>STOP</name>
+              <description>Stop</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SLAVE</name>
+              <description>Slave</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>COUNT16 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Count Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x2</dimIncrement>
+          <name>CC%s</name>
+          <description>COUNT16 Compare/Capture</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>CC</name>
+              <description>Compare/Capture Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- TcCount16 -->
+       <cluster>
+        <name>COUNT32</name>
+        <description>32-bit Counter Mode</description>
+        <alternateCluster>COUNT8</alternateCluster>
+        <headerStructName>TcCount32</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>TC Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Counter in 16-bit mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT8</name>
+                  <description>Counter in 8-bit mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Counter in 32-bit mode</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>WAVEGEN</name>
+              <description>Waveform Generation Operation</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MPWM</name>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Prescaler: GCLK_TC</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Prescaler: GCLK_TC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Prescaler: GCLK_TC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Prescaler: GCLK_TC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Prescaler: GCLK_TC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Prescaler: GCLK_TC/64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Prescaler: GCLK_TC/256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>Prescaler: GCLK_TC/1024</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCSYNC</name>
+              <description>Prescaler and Counter Synchronization</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSYNCSelect</name>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>Reload or reset the counter on next generic clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PRESC</name>
+                  <description>Reload or reset the counter on next prescaler clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNC</name>
+                  <description>Reload or reset the counter on next generic clock. Reset the prescaler counter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBCLR</name>
+          <description>Control B Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <resetValue>0x02</resetValue>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBSET</name>
+          <description>Control B Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLC</name>
+          <description>Control C</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>INVEN0</name>
+              <description>Output Waveform 0 Invert Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN1</name>
+              <description>Output Waveform 1 Invert Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN0</name>
+              <description>Capture Channel 0 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN1</name>
+              <description>Capture Channel 1 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>EVACT</name>
+              <description>Event Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACTSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Start, restart or retrigger TC on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT</name>
+                  <description>Count on event</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Start TC on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PPW</name>
+                  <description>Period captured in CC0, pulse width in CC1</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWP</name>
+                  <description>Period captured in CC1, pulse width in CC0</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TCINV</name>
+              <description>TC Inverted Event Input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI</name>
+              <description>TC Event Input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow/Underflow Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO0</name>
+              <description>Match or Capture Channel 0 Event Output Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO1</name>
+              <description>Match or Capture Channel 1 Event Output Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x0D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0F</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x08</resetValue>
+          <fields>
+            <field>
+              <name>STOP</name>
+              <description>Stop</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SLAVE</name>
+              <description>Slave</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>COUNT32 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Count Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s</name>
+          <description>COUNT32 Compare/Capture</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CC</name>
+              <description>Compare/Capture Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- TcCount32 -->
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="TC3">
+      <name>TC4</name>
+      <description>Basic Timer Counter 4</description>
+      <baseAddress>0x42003000</baseAddress>
+      <interrupt>
+        <name>TC4</name>
+        <value>19</value>
+      </interrupt>
+    </peripheral>
+    <peripheral derivedFrom="TC3">
+      <name>TC5</name>
+      <description>Basic Timer Counter 5</description>
+      <baseAddress>0x42003400</baseAddress>
+      <interrupt>
+        <name>TC5</name>
+        <value>20</value>
+      </interrupt>
+    </peripheral>
+    <peripheral derivedFrom="TC3">
+      <name>TC6</name>
+      <description>Basic Timer Counter 6</description>
+      <baseAddress>0x42003800</baseAddress>
+      <interrupt>
+        <name>TC6</name>
+        <value>21</value>
+      </interrupt>
+    </peripheral>
+    <peripheral derivedFrom="TC3">
+      <name>TC7</name>
+      <description>Basic Timer Counter 7</description>
+      <baseAddress>0x42003C00</baseAddress>
+      <interrupt>
+        <name>TC7</name>
+        <value>22</value>
+      </interrupt>
+    </peripheral>
+    <peripheral>
+      <name>TCC0</name>
+      <version>1.0.1</version>
+      <description>Timer Counter Control 0</description>
+      <groupName>TCC</groupName>
+      <prependToName>TCC_</prependToName>
+      <baseAddress>0x42002000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x090</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>TCC0</name>
+        <value>15</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RESOLUTION</name>
+              <description>Enhanced Resolution</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>RESOLUTIONSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>Dithering is disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DITH4</name>
+                  <description>Dithering is done every 16 PWM frames</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DITH5</name>
+                  <description>Dithering is done every 32 PWM frames</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DITH6</name>
+                  <description>Dithering is done every 64 PWM frames</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>No division</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Divide by 256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>Divide by 1024</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCSYNC</name>
+              <description>Prescaler and Counter Synchronization Selection</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSYNCSelect</name>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>Reload or reset counter on next GCLK</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PRESC</name>
+                  <description>Reload or reset counter on next prescaler clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNC</name>
+                  <description>Reload or reset counter on next GCLK and reset prescaler counter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ALOCK</name>
+              <description>Auto Lock</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN0</name>
+              <description>Capture Channel 0 Enable</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN1</name>
+              <description>Capture Channel 1 Enable</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN2</name>
+              <description>Capture Channel 2 Enable</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN3</name>
+              <description>Capture Channel 3 Enable</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBCLR</name>
+          <description>Control B Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LUPD</name>
+              <description>Lock Update</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IDXCMD</name>
+              <description>Ramp Index Command</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>IDXCMDSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Command disabled: Index toggles between cycles A and B</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Set index: cycle B will be forced in the next cycle</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLEAR</name>
+                  <description>Clear index: cycle A will be forced in the next cycle</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HOLD</name>
+                  <description>Hold index: the next cycle will be the same as the current cycle</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>TCC Command</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Clear start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UPDATE</name>
+                  <description>Force update of double buffered registers</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>READSYNC</name>
+                  <description>Force COUNT read synchronization</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBSET</name>
+          <description>Control B Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LUPD</name>
+              <description>Lock Update</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IDXCMD</name>
+              <description>Ramp Index Command</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>IDXCMDSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Command disabled: Index toggles between cycles A and B</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Set index: cycle B will be forced in the next cycle</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLEAR</name>
+                  <description>Clear index: cycle A will be forced in the next cycle</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HOLD</name>
+                  <description>Hold index: the next cycle will be the same as the current cycle</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>TCC Command</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Clear start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UPDATE</name>
+                  <description>Force update of double buffered registers</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>READSYNC</name>
+                  <description>Force COUNT read synchronization</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>Synchronization Busy</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Swrst Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTRLB</name>
+              <description>Ctrlb Busy</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STATUS</name>
+              <description>Status Busy</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COUNT</name>
+              <description>Count Busy</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PATT</name>
+              <description>Pattern Busy</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAVE</name>
+              <description>Wave Busy</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Period busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CC0</name>
+              <description>Compare Channel 0 Busy</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CC1</name>
+              <description>Compare Channel 1 Busy</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CC2</name>
+              <description>Compare Channel 2 Busy</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CC3</name>
+              <description>Compare Channel 3 Busy</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PATTB</name>
+              <description>Pattern Buffer Busy</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAVEB</name>
+              <description>Wave Buffer Busy</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Busy</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCB0</name>
+              <description>Compare Channel Buffer 0 Busy</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCB1</name>
+              <description>Compare Channel Buffer 1 Busy</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCB2</name>
+              <description>Compare Channel Buffer 2 Busy</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCB3</name>
+              <description>Compare Channel Buffer 3 Busy</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FCTRLA</name>
+          <description>Recoverable Fault A Configuration</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SRC</name>
+              <description>Fault A Source</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SRCSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Fault input disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ENABLE</name>
+                  <description>MCEx (x=0,1) event input</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INVERT</name>
+                  <description>Inverted MCEx (x=0,1) event input</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ALTFAULT</name>
+                  <description>Alternate fault (A or B) state at the end of the previous period</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>KEEP</name>
+              <description>Fault A Keeper</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>QUAL</name>
+              <description>Fault A Qualification</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BLANK</name>
+              <description>Fault A Blanking Mode</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>BLANKSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No blanking applied</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Blanking applied from rising edge of the output waveform</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Blanking applied from falling edge of the output waveform</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Blanking applied from each toggle of the output waveform</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RESTART</name>
+              <description>Fault A Restart</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HALT</name>
+              <description>Fault A Halt Mode</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>HALTSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Halt action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HW</name>
+                  <description>Hardware halt action</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SW</name>
+                  <description>Software halt action</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NR</name>
+                  <description>Non-recoverable fault</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CHSEL</name>
+              <description>Fault A Capture Channel</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CHSELSelect</name>
+                <enumeratedValue>
+                  <name>CC0</name>
+                  <description>Capture value stored in channel 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC1</name>
+                  <description>Capture value stored in channel 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC2</name>
+                  <description>Capture value stored in channel 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC3</name>
+                  <description>Capture value stored in channel 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CAPTURE</name>
+              <description>Fault A Capture Action</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CAPTURESelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>No capture</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPT</name>
+                  <description>Capture on fault</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMIN</name>
+                  <description>Minimum capture</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMAX</name>
+                  <description>Maximum capture</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOCMIN</name>
+                  <description>Minimum local detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOCMAX</name>
+                  <description>Maximum local detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DERIV0</name>
+                  <description>Minimum and maximum local detection</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>BLANKVAL</name>
+              <description>Fault A Blanking Time</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>FILTERVAL</name>
+              <description>Fault A Filter Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FCTRLB</name>
+          <description>Recoverable Fault B Configuration</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SRC</name>
+              <description>Fault B Source</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SRCSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Fault input disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ENABLE</name>
+                  <description>MCEx (x=0,1) event input</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INVERT</name>
+                  <description>Inverted MCEx (x=0,1) event input</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ALTFAULT</name>
+                  <description>Alternate fault (A or B) state at the end of the previous period</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>KEEP</name>
+              <description>Fault B Keeper</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>QUAL</name>
+              <description>Fault B Qualification</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BLANK</name>
+              <description>Fault B Blanking Mode</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>BLANKSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No blanking applied</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Blanking applied from rising edge of the output waveform</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Blanking applied from falling edge of the output waveform</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Blanking applied from each toggle of the output waveform</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RESTART</name>
+              <description>Fault B Restart</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HALT</name>
+              <description>Fault B Halt Mode</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>HALTSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Halt action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HW</name>
+                  <description>Hardware halt action</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SW</name>
+                  <description>Software halt action</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NR</name>
+                  <description>Non-recoverable fault</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CHSEL</name>
+              <description>Fault B Capture Channel</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CHSELSelect</name>
+                <enumeratedValue>
+                  <name>CC0</name>
+                  <description>Capture value stored in channel 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC1</name>
+                  <description>Capture value stored in channel 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC2</name>
+                  <description>Capture value stored in channel 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC3</name>
+                  <description>Capture value stored in channel 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CAPTURE</name>
+              <description>Fault B Capture Action</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CAPTURESelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>No capture</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPT</name>
+                  <description>Capture on fault</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMIN</name>
+                  <description>Minimum capture</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMAX</name>
+                  <description>Maximum capture</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOCMIN</name>
+                  <description>Minimum local detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOCMAX</name>
+                  <description>Maximum local detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DERIV0</name>
+                  <description>Minimum and maximum local detection</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>BLANKVAL</name>
+              <description>Fault B Blanking Time</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>FILTERVAL</name>
+              <description>Fault B Filter Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WEXCTRL</name>
+          <description>Waveform Extension Configuration</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OTMX</name>
+              <description>Output Matrix</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>DTIEN0</name>
+              <description>Dead-time Insertion Generator 0 Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DTIEN1</name>
+              <description>Dead-time Insertion Generator 1 Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DTIEN2</name>
+              <description>Dead-time Insertion Generator 2 Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DTIEN3</name>
+              <description>Dead-time Insertion Generator 3 Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DTLS</name>
+              <description>Dead-time Low Side Outputs Value</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>DTHS</name>
+              <description>Dead-time High Side Outputs Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DRVCTRL</name>
+          <description>Driver Control</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>NRE0</name>
+              <description>Non-Recoverable State 0 Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE1</name>
+              <description>Non-Recoverable State 1 Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE2</name>
+              <description>Non-Recoverable State 2 Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE3</name>
+              <description>Non-Recoverable State 3 Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE4</name>
+              <description>Non-Recoverable State 4 Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE5</name>
+              <description>Non-Recoverable State 5 Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE6</name>
+              <description>Non-Recoverable State 6 Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE7</name>
+              <description>Non-Recoverable State 7 Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV0</name>
+              <description>Non-Recoverable State 0 Output Value</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV1</name>
+              <description>Non-Recoverable State 1 Output Value</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV2</name>
+              <description>Non-Recoverable State 2 Output Value</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV3</name>
+              <description>Non-Recoverable State 3 Output Value</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV4</name>
+              <description>Non-Recoverable State 4 Output Value</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV5</name>
+              <description>Non-Recoverable State 5 Output Value</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV6</name>
+              <description>Non-Recoverable State 6 Output Value</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV7</name>
+              <description>Non-Recoverable State 7 Output Value</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN0</name>
+              <description>Output Waveform 0 Inversion</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN1</name>
+              <description>Output Waveform 1 Inversion</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN2</name>
+              <description>Output Waveform 2 Inversion</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN3</name>
+              <description>Output Waveform 3 Inversion</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN4</name>
+              <description>Output Waveform 4 Inversion</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN5</name>
+              <description>Output Waveform 5 Inversion</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN6</name>
+              <description>Output Waveform 6 Inversion</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN7</name>
+              <description>Output Waveform 7 Inversion</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FILTERVAL0</name>
+              <description>Non-Recoverable Fault Input 0 Filter Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>FILTERVAL1</name>
+              <description>Non-Recoverable Fault Input 1 Filter Value</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x1E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Running Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FDDBD</name>
+              <description>Fault Detection on Debug Break Detection</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EVACT0</name>
+              <description>Timer/counter Input Event0 Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACT0Select</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Start, restart or re-trigger counter on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNTEV</name>
+                  <description>Count on event</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Start counter on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INC</name>
+                  <description>Increment counter on event</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT</name>
+                  <description>Count on active state of asynchronous event</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FAULT</name>
+                  <description>Non-recoverable fault</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>EVACT1</name>
+              <description>Timer/counter Input Event1 Action</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACT1Select</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Re-trigger counter on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIR</name>
+                  <description>Direction control</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Stop counter on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DEC</name>
+                  <description>Decrement counter on event</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PPW</name>
+                  <description>Period capture value in CC0 register, pulse width capture value in CC1 register</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWP</name>
+                  <description>Period capture value in CC1 register, pulse width capture value in CC0 register</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FAULT</name>
+                  <description>Non-recoverable fault</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CNTSEL</name>
+              <description>Timer/counter Output Event Mode</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CNTSELSelect</name>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>An interrupt/event is generated when a new counter cycle starts</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>END</name>
+                  <description>An interrupt/event is generated when a counter cycle ends</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BETWEEN</name>
+                  <description>An interrupt/event is generated when a counter cycle ends, except for the first and last cycles</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOUNDARY</name>
+                  <description>An interrupt/event is generated when a new counter cycle starts or a counter cycle ends</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow/Underflow Output Event Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRGEO</name>
+              <description>Retrigger Output Event Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CNTEO</name>
+              <description>Timer/counter Output Event Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCINV0</name>
+              <description>Inverted Event 0 Input Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCINV1</name>
+              <description>Inverted Event 1 Input Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI0</name>
+              <description>Timer/counter Event 0 Input Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI1</name>
+              <description>Timer/counter Event 1 Input Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEI0</name>
+              <description>Match or Capture Channel 0 Event Input Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEI1</name>
+              <description>Match or Capture Channel 1 Event Input Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEI2</name>
+              <description>Match or Capture Channel 2 Event Input Enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEI3</name>
+              <description>Match or Capture Channel 3 Event Input Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO0</name>
+              <description>Match or Capture Channel 0 Event Output Enable</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO1</name>
+              <description>Match or Capture Channel 1 Event Output Enable</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO2</name>
+              <description>Match or Capture Channel 2 Event Output Enable</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO3</name>
+              <description>Match or Capture Channel 3 Event Output Enable</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRG</name>
+              <description>Retrigger Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CNT</name>
+              <description>Counter Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFS</name>
+              <description>Non-Recoverable Debug Fault Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTA</name>
+              <description>Recoverable Fault A Interrupt Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTB</name>
+              <description>Recoverable Fault B Interrupt Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT0</name>
+              <description>Non-Recoverable Fault 0 Interrupt Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT1</name>
+              <description>Non-Recoverable Fault 1 Interrupt Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC2</name>
+              <description>Match or Capture Channel 2 Interrupt Enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC3</name>
+              <description>Match or Capture Channel 3 Interrupt Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRG</name>
+              <description>Retrigger Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CNT</name>
+              <description>Counter Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFS</name>
+              <description>Non-Recoverable Debug Fault Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTA</name>
+              <description>Recoverable Fault A Interrupt Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTB</name>
+              <description>Recoverable Fault B Interrupt Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT0</name>
+              <description>Non-Recoverable Fault 0 Interrupt Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT1</name>
+              <description>Non-Recoverable Fault 1 Interrupt Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC2</name>
+              <description>Match or Capture Channel 2 Interrupt Enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC3</name>
+              <description>Match or Capture Channel 3 Interrupt Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRG</name>
+              <description>Retrigger</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CNT</name>
+              <description>Counter</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFS</name>
+              <description>Non-Recoverable Debug Fault</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTA</name>
+              <description>Recoverable Fault A</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTB</name>
+              <description>Recoverable Fault B</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT0</name>
+              <description>Non-Recoverable Fault 0</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT1</name>
+              <description>Non-Recoverable Fault 1</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture 0</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture 1</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC2</name>
+              <description>Match or Capture 2</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC3</name>
+              <description>Match or Capture 3</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x30</addressOffset>
+          <size>32</size>
+          <resetValue>0x00000001</resetValue>
+          <fields>
+            <field>
+              <name>STOP</name>
+              <description>Stop</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>IDX</name>
+              <description>Ramp</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFS</name>
+              <description>Non-Recoverable Debug Fault State</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SLAVE</name>
+              <description>Slave</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PATTBV</name>
+              <description>Pattern Buffer Valid</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAVEBV</name>
+              <description>Wave Buffer Valid</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PERBV</name>
+              <description>Period Buffer Valid</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTAIN</name>
+              <description>Recoverable Fault A Input</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FAULTBIN</name>
+              <description>Recoverable Fault B Input</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FAULT0IN</name>
+              <description>Non-Recoverable Fault0 Input</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FAULT1IN</name>
+              <description>Non-Recoverable Fault1 Input</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FAULTA</name>
+              <description>Recoverable Fault A State</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTB</name>
+              <description>Recoverable Fault B State</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT0</name>
+              <description>Non-Recoverable Fault 0 State</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT1</name>
+              <description>Non-Recoverable Fault 1 State</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCBV0</name>
+              <description>Compare Channel 0 Buffer Valid</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCBV1</name>
+              <description>Compare Channel 1 Buffer Valid</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCBV2</name>
+              <description>Compare Channel 2 Buffer Valid</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCBV3</name>
+              <description>Compare Channel 3 Buffer Valid</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMP0</name>
+              <description>Compare Channel 0 Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CMP1</name>
+              <description>Compare Channel 1 Value</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CMP2</name>
+              <description>Compare Channel 2 Value</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CMP3</name>
+              <description>Compare Channel 3 Value</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>Count</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT_DITH4</name>
+          <description>Count</description>
+          <alternateRegister>COUNT</alternateRegister>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT_DITH5</name>
+          <description>Count</description>
+          <alternateRegister>COUNT</alternateRegister>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT_DITH6</name>
+          <description>Count</description>
+          <alternateRegister>COUNT</alternateRegister>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PATT</name>
+          <description>Pattern</description>
+          <addressOffset>0x38</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PGE0</name>
+              <description>Pattern Generator 0 Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE1</name>
+              <description>Pattern Generator 1 Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE2</name>
+              <description>Pattern Generator 2 Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE3</name>
+              <description>Pattern Generator 3 Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE4</name>
+              <description>Pattern Generator 4 Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE5</name>
+              <description>Pattern Generator 5 Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE6</name>
+              <description>Pattern Generator 6 Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE7</name>
+              <description>Pattern Generator 7 Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV0</name>
+              <description>Pattern Generator 0 Output Value</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV1</name>
+              <description>Pattern Generator 1 Output Value</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV2</name>
+              <description>Pattern Generator 2 Output Value</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV3</name>
+              <description>Pattern Generator 3 Output Value</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV4</name>
+              <description>Pattern Generator 4 Output Value</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV5</name>
+              <description>Pattern Generator 5 Output Value</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV6</name>
+              <description>Pattern Generator 6 Output Value</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV7</name>
+              <description>Pattern Generator 7 Output Value</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WAVE</name>
+          <description>Waveform Control</description>
+          <addressOffset>0x3C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WAVEGEN</name>
+              <description>Waveform Generation</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <description>Normal frequency</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <description>Match frequency</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <description>Normal PWM</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSCRITICAL</name>
+                  <description>Dual-slope critical</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSBOTTOM</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches ZERO</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSBOTH</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches ZERO or TOP</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSTOP</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches TOP</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RAMP</name>
+              <description>Ramp Mode</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>RAMPSelect</name>
+                <enumeratedValue>
+                  <name>RAMP1</name>
+                  <description>RAMP1 operation</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RAMP2A</name>
+                  <description>Alternative RAMP2 operation</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RAMP2</name>
+                  <description>RAMP2 operation</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CIPEREN</name>
+              <description>Circular period Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCEN0</name>
+              <description>Circular Channel 0 Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCEN1</name>
+              <description>Circular Channel 1 Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCEN2</name>
+              <description>Circular Channel 2 Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCEN3</name>
+              <description>Circular Channel 3 Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POL0</name>
+              <description>Channel 0 Polarity</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POL1</name>
+              <description>Channel 1 Polarity</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POL2</name>
+              <description>Channel 2 Polarity</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POL3</name>
+              <description>Channel 3 Polarity</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAP0</name>
+              <description>Swap DTI Output Pair 0</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAP1</name>
+              <description>Swap DTI Output Pair 1</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAP2</name>
+              <description>Swap DTI Output Pair 2</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAP3</name>
+              <description>Swap DTI Output Pair 3</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER</name>
+          <description>Period</description>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER_DITH4</name>
+          <description>Period</description>
+          <alternateRegister>PER</alternateRegister>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER_DITH5</name>
+          <description>Period</description>
+          <alternateRegister>PER</alternateRegister>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER_DITH6</name>
+          <description>Period</description>
+          <alternateRegister>PER</alternateRegister>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s</name>
+          <description>Compare and Capture</description>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CC</name>
+              <description>Channel Compare/Capture Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s_DITH4</name>
+          <description>Compare and Capture</description>
+          <alternateRegister>CC%s</alternateRegister>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>CC</name>
+              <description>Channel Compare/Capture Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s_DITH5</name>
+          <description>Compare and Capture</description>
+          <alternateRegister>CC%s</alternateRegister>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>CC</name>
+              <description>Channel Compare/Capture Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s_DITH6</name>
+          <description>Compare and Capture</description>
+          <alternateRegister>CC%s</alternateRegister>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>CC</name>
+              <description>Channel Compare/Capture Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PATTB</name>
+          <description>Pattern Buffer</description>
+          <addressOffset>0x64</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PGEB0</name>
+              <description>Pattern Generator 0 Output Enable Buffer</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB1</name>
+              <description>Pattern Generator 1 Output Enable Buffer</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB2</name>
+              <description>Pattern Generator 2 Output Enable Buffer</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB3</name>
+              <description>Pattern Generator 3 Output Enable Buffer</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB4</name>
+              <description>Pattern Generator 4 Output Enable Buffer</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB5</name>
+              <description>Pattern Generator 5 Output Enable Buffer</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB6</name>
+              <description>Pattern Generator 6 Output Enable Buffer</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB7</name>
+              <description>Pattern Generator 7 Output Enable Buffer</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB0</name>
+              <description>Pattern Generator 0 Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB1</name>
+              <description>Pattern Generator 1 Output Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB2</name>
+              <description>Pattern Generator 2 Output Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB3</name>
+              <description>Pattern Generator 3 Output Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB4</name>
+              <description>Pattern Generator 4 Output Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB5</name>
+              <description>Pattern Generator 5 Output Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB6</name>
+              <description>Pattern Generator 6 Output Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB7</name>
+              <description>Pattern Generator 7 Output Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WAVEB</name>
+          <description>Waveform Control Buffer</description>
+          <addressOffset>0x68</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WAVEGENB</name>
+              <description>Waveform Generation Buffer</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENBSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <description>Normal frequency</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <description>Match frequency</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <description>Normal PWM</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSCRITICAL</name>
+                  <description>Dual-slope critical</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSBOTTOM</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches ZERO</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSBOTH</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches ZERO or TOP</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSTOP</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches TOP</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RAMPB</name>
+              <description>Ramp Mode Buffer</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>RAMPBSelect</name>
+                <enumeratedValue>
+                  <name>RAMP1</name>
+                  <description>RAMP1 operation</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RAMP2A</name>
+                  <description>Alternative RAMP2 operation</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RAMP2</name>
+                  <description>RAMP2 operation</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CIPERENB</name>
+              <description>Circular Period Enable Buffer</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCENB0</name>
+              <description>Circular Channel 0 Enable Buffer</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCENB1</name>
+              <description>Circular Channel 1 Enable Buffer</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCENB2</name>
+              <description>Circular Channel 2 Enable Buffer</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCENB3</name>
+              <description>Circular Channel 3 Enable Buffer</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POLB0</name>
+              <description>Channel 0 Polarity Buffer</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POLB1</name>
+              <description>Channel 1 Polarity Buffer</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POLB2</name>
+              <description>Channel 2 Polarity Buffer</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POLB3</name>
+              <description>Channel 3 Polarity Buffer</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAPB0</name>
+              <description>Swap DTI Output Pair 0 Buffer</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAPB1</name>
+              <description>Swap DTI Output Pair 1 Buffer</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAPB2</name>
+              <description>Swap DTI Output Pair 2 Buffer</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAPB3</name>
+              <description>Swap DTI Output Pair 3 Buffer</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PERB</name>
+          <description>Period Buffer</description>
+          <addressOffset>0x6C</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PERB_DITH4</name>
+          <description>Period Buffer</description>
+          <alternateRegister>PERB</alternateRegister>
+          <addressOffset>0x6C</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PERB_DITH5</name>
+          <description>Period Buffer</description>
+          <alternateRegister>PERB</alternateRegister>
+          <addressOffset>0x6C</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PERB_DITH6</name>
+          <description>Period Buffer</description>
+          <alternateRegister>PERB</alternateRegister>
+          <addressOffset>0x6C</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CCB%s</name>
+          <description>Compare and Capture Buffer</description>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CCB</name>
+              <description>Channel Compare/Capture Buffer Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CCB%s_DITH4</name>
+          <description>Compare and Capture Buffer</description>
+          <alternateRegister>CCB%s</alternateRegister>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>CCB</name>
+              <description>Channel Compare/Capture Buffer Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CCB%s_DITH5</name>
+          <description>Compare and Capture Buffer</description>
+          <alternateRegister>CCB%s</alternateRegister>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>CCB</name>
+              <description>Channel Compare/Capture Buffer Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CCB%s_DITH6</name>
+          <description>Compare and Capture Buffer</description>
+          <alternateRegister>CCB%s</alternateRegister>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>CCB</name>
+              <description>Channel Compare/Capture Buffer Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="TCC0">
+      <name>TCC1</name>
+      <description>Timer Counter Control 1</description>
+      <baseAddress>0x42002400</baseAddress>
+      <interrupt>
+        <name>TCC1</name>
+        <value>16</value>
+      </interrupt>
+    </peripheral>
+    <peripheral derivedFrom="TCC0">
+      <name>TCC2</name>
+      <description>Timer Counter Control 2</description>
+      <baseAddress>0x42002800</baseAddress>
+      <interrupt>
+        <name>TCC2</name>
+        <value>17</value>
+      </interrupt>
+    </peripheral>
+    <peripheral>
+      <name>USB</name>
+      <version>1.0.1</version>
+      <description>Universal Serial Bus</description>
+      <groupName>USB</groupName>
+      <prependToName>USB_</prependToName>
+      <baseAddress>0x41005000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x1000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>USB</name>
+        <value>7</value>
+      </interrupt>
+      <registers>
+       <cluster>
+        <name>DEVICE</name>
+        <description>USB is Device</description>
+        <headerStructName>UsbDevice</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x000</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>DEVICE</name>
+                  <description>Device Mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HOST</name>
+                  <description>Host Mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>Synchronization Busy</description>
+          <addressOffset>0x002</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>QOSCTRL</name>
+          <description>USB Quality Of Service</description>
+          <addressOffset>0x003</addressOffset>
+          <size>8</size>
+          <resetValue>0x05</resetValue>
+          <fields>
+            <field>
+              <name>CQOS</name>
+              <description>Configuration Quality of Service</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CQOSSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Background (no sensitive operation)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Sensitive Bandwidth</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MEDIUM</name>
+                  <description>Sensitive Latency</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>Critical Latency</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>DQOS</name>
+              <description>Data Quality of Service</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>DQOSSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Background (no sensitive operation)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Sensitive Bandwidth</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MEDIUM</name>
+                  <description>Sensitive Latency</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>Critical Latency</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>DEVICE Control B</description>
+          <addressOffset>0x008</addressOffset>
+          <size>16</size>
+          <resetValue>0x0001</resetValue>
+          <fields>
+            <field>
+              <name>DETACH</name>
+              <description>Detach</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>UPRSM</name>
+              <description>Upstream Resume</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPDCONF</name>
+              <description>Speed Configuration</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SPDCONFSelect</name>
+                <enumeratedValue>
+                  <name>FS</name>
+                  <description>FS : Full Speed</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LS</name>
+                  <description>LS : Low Speed</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HS</name>
+                  <description>HS : High Speed capable</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HSTM</name>
+                  <description>HSTM: High Speed Test Mode (force high-speed mode for test mode)</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>NREPLY</name>
+              <description>No Reply</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TSTJ</name>
+              <description>Test mode J</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TSTK</name>
+              <description>Test mode K</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TSTPCKT</name>
+              <description>Test packet mode</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OPMODE2</name>
+              <description>Specific Operational Mode</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GNAK</name>
+              <description>Global NAK</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMHDSK</name>
+              <description>Link Power Management Handshake</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>LPMHDSKSelect</name>
+                <enumeratedValue>
+                  <name>NO</name>
+                  <description>No handshake. LPM is not supported</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ACK</name>
+                  <description>ACK</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NYET</name>
+                  <description>NYET</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STALL</name>
+                  <description>STALL</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DADD</name>
+          <description>DEVICE Device Address</description>
+          <addressOffset>0x00A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DADD</name>
+              <description>Device Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+            <field>
+              <name>ADDEN</name>
+              <description>Device Address Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>DEVICE Status</description>
+          <addressOffset>0x00C</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x40</resetValue>
+          <fields>
+            <field>
+              <name>SPEED</name>
+              <description>Speed Status</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>SPEEDSelect</name>
+                <enumeratedValue>
+                  <name>FS</name>
+                  <description>Full-speed mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HS</name>
+                  <description>High-speed mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LS</name>
+                  <description>Low-speed mode</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LINESTATE</name>
+              <description>USB Line State Status</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>LINESTATESelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>SE0/RESET</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>FS-J or LS-K State</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>FS-K or LS-J State</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FSMSTATUS</name>
+          <description>Finite State Machine Status</description>
+          <addressOffset>0x00D</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x01</resetValue>
+          <fields>
+            <field>
+              <name>FSMSTATE</name>
+              <description>Fine State Machine Status</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>FSMSTATESelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>OFF (L3). It corresponds to the powered-off, disconnected, and disabled state</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ON</name>
+                  <description>ON (L0). It corresponds to the Idle and Active states</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SUSPEND</name>
+                  <description>SUSPEND (L2)</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SLEEP</name>
+                  <description>SLEEP (L1)</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DNRESUME</name>
+                  <description>DNRESUME. Down Stream Resume.</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UPRESUME</name>
+                  <description>UPRESUME. Up Stream Resume.</description>
+                  <value>0x20</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESET</name>
+                  <description>RESET. USB lines Reset.</description>
+                  <value>0x40</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FNUM</name>
+          <description>DEVICE Device Frame Number</description>
+          <addressOffset>0x010</addressOffset>
+          <size>16</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>MFNUM</name>
+              <description>Micro Frame Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FNUM</name>
+              <description>Frame Number</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>11</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FNCERR</name>
+              <description>Frame Number CRC Error</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>DEVICE Device Interrupt Enable Clear</description>
+          <addressOffset>0x014</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SUSPEND</name>
+              <description>Suspend Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MSOF</name>
+              <description>Micro Start of Frame Interrupt Enable in High Speed Mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SOF</name>
+              <description>Start Of Frame Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORST</name>
+              <description>End of Reset Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUP</name>
+              <description>Wake Up Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORSM</name>
+              <description>End Of Resume Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>UPRSM</name>
+              <description>Upstream Resume Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RAMACER</name>
+              <description>Ram Access Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMNYET</name>
+              <description>Link Power Management Not Yet Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMSUSP</name>
+              <description>Link Power Management Suspend Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>DEVICE Device Interrupt Enable Set</description>
+          <addressOffset>0x018</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SUSPEND</name>
+              <description>Suspend Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MSOF</name>
+              <description>Micro Start of Frame Interrupt Enable in High Speed Mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SOF</name>
+              <description>Start Of Frame Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORST</name>
+              <description>End of Reset Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUP</name>
+              <description>Wake Up Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORSM</name>
+              <description>End Of Resume Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>UPRSM</name>
+              <description>Upstream Resume Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RAMACER</name>
+              <description>Ram Access Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMNYET</name>
+              <description>Link Power Management Not Yet Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMSUSP</name>
+              <description>Link Power Management Suspend Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>DEVICE Device Interrupt Flag</description>
+          <addressOffset>0x01C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SUSPEND</name>
+              <description>Suspend</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MSOF</name>
+              <description>Micro Start of Frame in High Speed Mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SOF</name>
+              <description>Start Of Frame</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORST</name>
+              <description>End of Reset</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUP</name>
+              <description>Wake Up</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORSM</name>
+              <description>End Of Resume</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>UPRSM</name>
+              <description>Upstream Resume</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RAMACER</name>
+              <description>Ram Access</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMNYET</name>
+              <description>Link Power Management Not Yet</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMSUSP</name>
+              <description>Link Power Management Suspend</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EPINTSMRY</name>
+          <description>DEVICE End Point Interrupt Summary</description>
+          <addressOffset>0x020</addressOffset>
+          <size>16</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>EPINT0</name>
+              <description>End Point 0 Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT1</name>
+              <description>End Point 1 Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT2</name>
+              <description>End Point 2 Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT3</name>
+              <description>End Point 3 Interrupt</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT4</name>
+              <description>End Point 4 Interrupt</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT5</name>
+              <description>End Point 5 Interrupt</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT6</name>
+              <description>End Point 6 Interrupt</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT7</name>
+              <description>End Point 7 Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DESCADD</name>
+          <description>Descriptor Address</description>
+          <addressOffset>0x024</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DESCADD</name>
+              <description>Descriptor Address Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PADCAL</name>
+          <description>USB PAD Calibration</description>
+          <addressOffset>0x028</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>TRANSP</name>
+              <description>USB Pad Transp calibration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>TRANSN</name>
+              <description>USB Pad Transn calibration</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>TRIM</name>
+              <description>USB Pad Trim calibration</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPCFG%s</name>
+          <description>DEVICE End Point Configuration</description>
+          <addressOffset>0x100</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EPTYPE0</name>
+              <description>End Point Type0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>EPTYPE1</name>
+              <description>End Point Type1</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>NYETDIS</name>
+              <description>NYET Token Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPSTATUSCLR%s</name>
+          <description>DEVICE End Point Pipe Status Clear</description>
+          <addressOffset>0x104</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>DTGLOUT</name>
+              <description>Data Toggle OUT Clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>DTGLIN</name>
+              <description>Data Toggle IN Clear</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CURBK</name>
+              <description>Curren Bank Clear</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>STALLRQ0</name>
+              <description>Stall 0 Request Clear</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>STALLRQ1</name>
+              <description>Stall 1 Request Clear</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BK0RDY</name>
+              <description>Bank 0 Ready Clear</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BK1RDY</name>
+              <description>Bank 1 Ready Clear</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPSTATUSSET%s</name>
+          <description>DEVICE End Point Pipe Status Set</description>
+          <addressOffset>0x105</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>DTGLOUT</name>
+              <description>Data Toggle OUT Set</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>DTGLIN</name>
+              <description>Data Toggle IN Set</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CURBK</name>
+              <description>Current Bank Set</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>STALLRQ0</name>
+              <description>Stall 0 Request Set</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>STALLRQ1</name>
+              <description>Stall 1 Request Set</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BK0RDY</name>
+              <description>Bank 0 Ready Set</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BK1RDY</name>
+              <description>Bank 1 Ready Set</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPSTATUS%s</name>
+          <description>DEVICE End Point Pipe Status</description>
+          <addressOffset>0x106</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>DTGLOUT</name>
+              <description>Data Toggle Out</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DTGLIN</name>
+              <description>Data Toggle In</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CURBK</name>
+              <description>Current Bank</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>STALLRQ0</name>
+              <description>Stall 0 Request</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>STALLRQ1</name>
+              <description>Stall 1 Request</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BK0RDY</name>
+              <description>Bank 0 ready</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BK1RDY</name>
+              <description>Bank 1 ready</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPINTFLAG%s</name>
+          <description>DEVICE End Point Interrupt Flag</description>
+          <addressOffset>0x107</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TRCPT0</name>
+              <description>Transfer Complete 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRCPT1</name>
+              <description>Transfer Complete 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL0</name>
+              <description>Error Flow 0</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL1</name>
+              <description>Error Flow 1</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXSTP</name>
+              <description>Received Setup</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL0</name>
+              <description>Stall 0 In/out</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL1</name>
+              <description>Stall 1 In/out</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPINTENCLR%s</name>
+          <description>DEVICE End Point Interrupt Clear Flag</description>
+          <addressOffset>0x108</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TRCPT0</name>
+              <description>Transfer Complete 0 Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRCPT1</name>
+              <description>Transfer Complete 1 Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL0</name>
+              <description>Error Flow 0 Interrupt Disable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL1</name>
+              <description>Error Flow 1 Interrupt Disable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXSTP</name>
+              <description>Received Setup Interrupt Disable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL0</name>
+              <description>Stall 0 In/Out Interrupt Disable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL1</name>
+              <description>Stall 1 In/Out Interrupt Disable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPINTENSET%s</name>
+          <description>DEVICE End Point Interrupt Set Flag</description>
+          <addressOffset>0x109</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TRCPT0</name>
+              <description>Transfer Complete 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRCPT1</name>
+              <description>Transfer Complete 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL0</name>
+              <description>Error Flow 0 Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL1</name>
+              <description>Error Flow 1 Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXSTP</name>
+              <description>Received Setup Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL0</name>
+              <description>Stall 0 In/out Interrupt enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL1</name>
+              <description>Stall 1 In/out Interrupt enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- UsbDevice -->
+       <cluster>
+        <name>HOST</name>
+        <description>USB is Host</description>
+        <alternateCluster>DEVICE</alternateCluster>
+        <headerStructName>UsbHost</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x000</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>DEVICE</name>
+                  <description>Device Mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HOST</name>
+                  <description>Host Mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>Synchronization Busy</description>
+          <addressOffset>0x002</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>QOSCTRL</name>
+          <description>USB Quality Of Service</description>
+          <addressOffset>0x003</addressOffset>
+          <size>8</size>
+          <resetValue>0x05</resetValue>
+          <fields>
+            <field>
+              <name>CQOS</name>
+              <description>Configuration Quality of Service</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CQOSSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Background (no sensitive operation)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Sensitive Bandwidth</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MEDIUM</name>
+                  <description>Sensitive Latency</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>Critical Latency</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>DQOS</name>
+              <description>Data Quality of Service</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>DQOSSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Background (no sensitive operation)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Sensitive Bandwidth</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MEDIUM</name>
+                  <description>Sensitive Latency</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>Critical Latency</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>HOST Control B</description>
+          <addressOffset>0x008</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>RESUME</name>
+              <description>Send USB Resume</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPDCONF</name>
+              <description>Speed Configuration for Host</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SPDCONFSelect</name>
+                <enumeratedValue>
+                  <name>NORMAL</name>
+                  <description>Normal mode:the host starts in full-speed mode and performs a high-speed reset to switch to the high speed mode if the downstream peripheral is high-speed capable.</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FS</name>
+                  <description>Full-speed:the host remains in full-speed mode whatever is the peripheral speed capability. Relevant in UTMI mode only.</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TSTJ</name>
+              <description>Test mode J</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TSTK</name>
+              <description>Test mode K</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SOFE</name>
+              <description>Start of Frame Generation Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BUSRESET</name>
+              <description>Send USB Reset</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>VBUSOK</name>
+              <description>VBUS is OK</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>L1RESUME</name>
+              <description>Send L1 Resume</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>HSOFC</name>
+          <description>HOST Host Start Of Frame Control</description>
+          <addressOffset>0x00A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>FLENC</name>
+              <description>Frame Length Control</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>FLENCE</name>
+              <description>Frame Length Control Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>HOST Status</description>
+          <addressOffset>0x00C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SPEED</name>
+              <description>Speed Status</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>LINESTATE</name>
+              <description>USB Line State Status</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FSMSTATUS</name>
+          <description>Finite State Machine Status</description>
+          <addressOffset>0x00D</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x01</resetValue>
+          <fields>
+            <field>
+              <name>FSMSTATE</name>
+              <description>Fine State Machine Status</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>FSMSTATESelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>OFF (L3). It corresponds to the powered-off, disconnected, and disabled state</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ON</name>
+                  <description>ON (L0). It corresponds to the Idle and Active states</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SUSPEND</name>
+                  <description>SUSPEND (L2)</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SLEEP</name>
+                  <description>SLEEP (L1)</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DNRESUME</name>
+                  <description>DNRESUME. Down Stream Resume.</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UPRESUME</name>
+                  <description>UPRESUME. Up Stream Resume.</description>
+                  <value>0x20</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESET</name>
+                  <description>RESET. USB lines Reset.</description>
+                  <value>0x40</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FNUM</name>
+          <description>HOST Host Frame Number</description>
+          <addressOffset>0x010</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>MFNUM</name>
+              <description>Micro Frame Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>FNUM</name>
+              <description>Frame Number</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>11</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FLENHIGH</name>
+          <description>HOST Host Frame Length</description>
+          <addressOffset>0x012</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>FLENHIGH</name>
+              <description>Frame Length</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>HOST Host Interrupt Enable Clear</description>
+          <addressOffset>0x014</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>HSOF</name>
+              <description>Host Start Of Frame Interrupt Disable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RST</name>
+              <description>BUS Reset Interrupt Disable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUP</name>
+              <description>Wake Up Interrupt Disable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DNRSM</name>
+              <description>DownStream to Device Interrupt Disable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>UPRSM</name>
+              <description>Upstream Resume from Device Interrupt Disable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RAMACER</name>
+              <description>Ram Access Interrupt Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DCONN</name>
+              <description>Device Connection Interrupt Disable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DDISC</name>
+              <description>Device Disconnection Interrupt Disable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>HOST Host Interrupt Enable Set</description>
+          <addressOffset>0x018</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>HSOF</name>
+              <description>Host Start Of Frame Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RST</name>
+              <description>Bus Reset Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUP</name>
+              <description>Wake Up Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DNRSM</name>
+              <description>DownStream to the Device Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>UPRSM</name>
+              <description>Upstream Resume fromthe device Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RAMACER</name>
+              <description>Ram Access Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DCONN</name>
+              <description>Link Power Management Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DDISC</name>
+              <description>Device Disconnection Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>HOST Host Interrupt Flag</description>
+          <addressOffset>0x01C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>HSOF</name>
+              <description>Host Start Of Frame</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RST</name>
+              <description>Bus Reset</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUP</name>
+              <description>Wake Up</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DNRSM</name>
+              <description>Downstream</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>UPRSM</name>
+              <description>Upstream Resume from the Device</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RAMACER</name>
+              <description>Ram Access</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DCONN</name>
+              <description>Device Connection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DDISC</name>
+              <description>Device Disconnection</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PINTSMRY</name>
+          <description>HOST Pipe Interrupt Summary</description>
+          <addressOffset>0x020</addressOffset>
+          <size>16</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>EPINT0</name>
+              <description>Pipe 0 Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT1</name>
+              <description>Pipe 1 Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT2</name>
+              <description>Pipe 2 Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT3</name>
+              <description>Pipe 3 Interrupt</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT4</name>
+              <description>Pipe 4 Interrupt</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT5</name>
+              <description>Pipe 5 Interrupt</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT6</name>
+              <description>Pipe 6 Interrupt</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT7</name>
+              <description>Pipe 7 Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DESCADD</name>
+          <description>Descriptor Address</description>
+          <addressOffset>0x024</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DESCADD</name>
+              <description>Descriptor Address Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PADCAL</name>
+          <description>USB PAD Calibration</description>
+          <addressOffset>0x028</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>TRANSP</name>
+              <description>USB Pad Transp calibration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>TRANSN</name>
+              <description>USB Pad Transn calibration</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>TRIM</name>
+              <description>USB Pad Trim calibration</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>PCFG%s</name>
+          <description>HOST End Point Configuration</description>
+          <addressOffset>0x100</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PTOKEN</name>
+              <description>Pipe Token</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>BK</name>
+              <description>Pipe Bank</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PTYPE</name>
+              <description>Pipe Type</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>BINTERVAL%s</name>
+          <description>HOST Bus Access Period of Pipe</description>
+          <addressOffset>0x103</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>BITINTERVAL</name>
+              <description>Bit Interval</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>PSTATUSCLR%s</name>
+          <description>HOST End Point Pipe Status Clear</description>
+          <addressOffset>0x104</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>DTGL</name>
+              <description>Data Toggle clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CURBK</name>
+              <description>Curren Bank clear</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>PFREEZE</name>
+              <description>Pipe Freeze Clear</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BK0RDY</name>
+              <description>Bank 0 Ready Clear</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BK1RDY</name>
+              <description>Bank 1 Ready Clear</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>PSTATUSSET%s</name>
+          <description>HOST End Point Pipe Status Set</description>
+          <addressOffset>0x105</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>DTGL</name>
+              <description>Data Toggle Set</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CURBK</name>
+              <description>Current Bank Set</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>PFREEZE</name>
+              <description>Pipe Freeze Set</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BK0RDY</name>
+              <description>Bank 0 Ready Set</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BK1RDY</name>
+              <description>Bank 1 Ready Set</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>PSTATUS%s</name>
+          <description>HOST End Point Pipe Status</description>
+          <addressOffset>0x106</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>DTGL</name>
+              <description>Data Toggle</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CURBK</name>
+              <description>Current Bank</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PFREEZE</name>
+              <description>Pipe Freeze</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BK0RDY</name>
+              <description>Bank 0 ready</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BK1RDY</name>
+              <description>Bank 1 ready</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>PINTFLAG%s</name>
+          <description>HOST Pipe Interrupt Flag</description>
+          <addressOffset>0x107</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TRCPT0</name>
+              <description>Transfer Complete 0 Interrupt Flag</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRCPT1</name>
+              <description>Transfer Complete 1 Interrupt Flag</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL</name>
+              <description>Error Flow Interrupt Flag</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PERR</name>
+              <description>Pipe Error Interrupt Flag</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXSTP</name>
+              <description>Transmit  Setup Interrupt Flag</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL</name>
+              <description>Stall Interrupt Flag</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>PINTENCLR%s</name>
+          <description>HOST Pipe Interrupt Flag Clear</description>
+          <addressOffset>0x108</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TRCPT0</name>
+              <description>Transfer Complete 0 Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRCPT1</name>
+              <description>Transfer Complete 1 Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL</name>
+              <description>Error Flow Interrupt Disable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PERR</name>
+              <description>Pipe Error Interrupt Disable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXSTP</name>
+              <description>Transmit  Setup Interrupt Disable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL</name>
+              <description>Stall Inetrrupt Disable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>PINTENSET%s</name>
+          <description>HOST Pipe Interrupt Flag Set</description>
+          <addressOffset>0x109</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TRCPT0</name>
+              <description>Transfer Complete 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRCPT1</name>
+              <description>Transfer Complete 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL</name>
+              <description>Error Flow Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PERR</name>
+              <description>Pipe Error Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXSTP</name>
+              <description>Transmit  Setup Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL</name>
+              <description>Stall Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- UsbHost -->
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>WDT</name>
+      <version>2.0.0</version>
+      <description>Watchdog Timer</description>
+      <groupName>WDT</groupName>
+      <prependToName>WDT_</prependToName>
+      <baseAddress>0x40001000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>WDT</name>
+        <value>2</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x0</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WEN</name>
+              <description>Watchdog Timer Window Mode Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ALWAYSON</name>
+              <description>Always-On</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CONFIG</name>
+          <description>Configuration</description>
+          <addressOffset>0x1</addressOffset>
+          <size>8</size>
+          <resetValue>0xBB</resetValue>
+          <fields>
+            <field>
+              <name>PER</name>
+              <description>Time-Out Period</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PERSelect</name>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 clock cycles</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 clock cycles</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 clock cycles</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 clock cycles</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 clock cycles</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 clock cycles</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 clock cycles</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1K</name>
+                  <description>1024 clock cycles</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2K</name>
+                  <description>2048 clock cycles</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4K</name>
+                  <description>4096 clock cycles</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8K</name>
+                  <description>8192 clock cycles</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16K</name>
+                  <description>16384 clock cycles</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>WINDOW</name>
+              <description>Window Mode Time-Out Period</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>WINDOWSelect</name>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 clock cycles</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 clock cycles</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 clock cycles</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 clock cycles</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 clock cycles</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 clock cycles</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 clock cycles</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1K</name>
+                  <description>1024 clock cycles</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2K</name>
+                  <description>2048 clock cycles</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4K</name>
+                  <description>4096 clock cycles</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8K</name>
+                  <description>8192 clock cycles</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16K</name>
+                  <description>16384 clock cycles</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EWCTRL</name>
+          <description>Early Warning Interrupt Control</description>
+          <addressOffset>0x2</addressOffset>
+          <size>8</size>
+          <resetValue>0x0B</resetValue>
+          <fields>
+            <field>
+              <name>EWOFFSET</name>
+              <description>Early Warning Interrupt Time Offset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>EWOFFSETSelect</name>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 clock cycles</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 clock cycles</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 clock cycles</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 clock cycles</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 clock cycles</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 clock cycles</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 clock cycles</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1K</name>
+                  <description>1024 clock cycles</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2K</name>
+                  <description>2048 clock cycles</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4K</name>
+                  <description>4096 clock cycles</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8K</name>
+                  <description>8192 clock cycles</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16K</name>
+                  <description>16384 clock cycles</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x4</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EW</name>
+              <description>Early Warning Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x5</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EW</name>
+              <description>Early Warning Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x6</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EW</name>
+              <description>Early Warning</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x7</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CLEAR</name>
+          <description>Clear</description>
+          <addressOffset>0x8</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>CLEAR</name>
+              <description>Watchdog Clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+              <access>write-only</access>
+              <enumeratedValues>
+                <name>CLEARSelect</name>
+                <enumeratedValue>
+                  <name>KEY</name>
+                  <description>Clear Key</description>
+                  <value>0xa5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+  </peripherals>
+</device>


### PR DESCRIPTION
The SAMD21J18A.svd has been removed by https://github.com/platformio/platform-atmelsam/commit/18233478f333a481615319f04106ad3183969300 I suppose this was an accident.

This one is from https://packs.download.microchip.com/ and more specifically from Microchip.SAMD21_DFP.3.4.116.