### PR TITLE
Fix missing flag for Adafruit PyPortal Titano

### DIFF
--- a/boards/adafruit_pyportal_m4_titano.json
+++ b/boards/adafruit_pyportal_m4_titano.json
@@ -7,6 +7,7 @@
     "cpu": "cortex-m4",
     "extra_flags": [
       "-DARDUINO_PYPORTAL_M4_TITANO",
+      "-DADAFRUIT_PYPORTAL_M4_TITANO",
       "-DADAFRUIT_PYPORTAL",
       "-D__SAMD51J20A__",
       "-D__SAMD51__",


### PR DESCRIPTION
Adafruit libraries and examples expect ADAFRUIT_PYPORTAL_M4_TITANO to be defined. 

See: https://github.com/adafruit/Adafruit_LvGL_Glue/blob/67c4d4a8d84b291232145e7f35bd24b7e01961c2/examples/hello_pyportal/hello_pyportal.ino#L28 
https://github.com/adafruit/Adafruit_NeoPixel_ZeroDMA/blob/cd852e819d7bb4d83db759290bbd3eb787683def/pins.h#L215