### PR TITLE
Add support for P1AM-100

### DIFF
--- a/boards/p1am100.json
+++ b/boards/p1am100.json
@@ -3,7 +3,7 @@
     "arduino": {
         "ldscript": "flash_with_bootloader.ld"
     },
-    "core": "samd",
+    "core": "arduino",
     "cpu": "cortex-m0plus",
     "extra_flags": "-DARDUINO_SAMD_MKRZERO -D__SAMD21G18A__ -DUSE_ARDUINO_MKR_PIN_LAYOUT",
     "f_cpu": "48000000L",


### PR DESCRIPTION
Hi,

This  adds the support for the P1AM-100 board which is based on the SAMD21. Very similar to the mkrzero.

Information about the hardware can be found here: https://github.com/facts-engineering/P1AM

Is there anything else required to implement this?

Resolves issues #98, #111, and #173

Best regards,
NeoGaius