### PR TITLE
Enable LTO support

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -55,13 +55,13 @@ upload_protocol = env.subst("$UPLOAD_PROTOCOL")
 build_mcu = env.get("BOARD_MCU", board.get("build.mcu", ""))
 
 env.Replace(
-    AR="arm-none-eabi-ar",
+    AR="arm-none-eabi-gcc-ar",
     AS="arm-none-eabi-as",
     CC="arm-none-eabi-gcc",
     CXX="arm-none-eabi-g++",
     GDB="arm-none-eabi-gdb",
     OBJCOPY="arm-none-eabi-objcopy",
-    RANLIB="arm-none-eabi-ranlib",
+    RANLIB="arm-none-eabi-gcc-ranlib",
     SIZETOOL="arm-none-eabi-size",
 
     ARFLAGS=["rc"],


### PR DESCRIPTION
Currently, this platform does not play nicely with GCCs Link Time Optimisation (enabled using the `-flto` flag). Due to the absence of the LTO plugin in binutils' ar. This can be fixed by using the respective `arm-none-eabi-gcc-ar` variant which is already included in the `toolchain-gccarmnoneeabi` package

The stm32 platform has already implemented the same enhancement: https://github.com/platformio/platform-ststm32/pull/419