### PR TITLE
Update platform.py

### DIFF
--- a/platform.py
+++ b/platform.py
@@ -151,7 +151,11 @@ class AtmelsamPlatform(PlatformBase):
 
             else:
                 openocd_chipname = debug.get("openocd_chipname")
-                assert openocd_chipname
+                
+                assert openocd_chipname, (
+                  "Missing openocd_chipname for %s" % board.id
+                )
+                
                 openocd_cmds = ["set CHIPNAME %s" % openocd_chipname]
                 if link == "stlink" and "at91sam3" in openocd_chipname:
                     openocd_cmds.append("set CPUTAPID 0x2ba01477")


### PR DESCRIPTION
Some boards in Marlin 2 trigger this assertion, preventing the boards list to load in platform I/O. This change at least makes is clear which board fails. But I think a warning would suffice here as well.