### PR TITLE
Add support for SAM4E (Baremetal example)

### DIFF
--- a/boards/sam4e8e_baremetal.json
+++ b/boards/sam4e8e_baremetal.json
@@ -1,0 +1,44 @@
+{
+  "build": {
+    "core": "baremetal",
+    "cpu": "cortex-m4",
+    "extra_flags": "-D__SAM4E8E__",
+    "f_cpu": "120000000L",
+    "hwids": [
+      [
+        "0x03EB",
+        "0x6124"
+      ]
+    ],
+    "mcu": "at91sam4e8e",
+    "usb_product": "Atmel SAM4",
+    "variant": "SAM4E8E_BM"
+  },
+  "debug": {
+    "jlink_device": "ATSAM4E8E",
+    "openocd_chipname": "atsam4E8E",
+    "openocd_target": "at91sam4XXX",
+    "svd_path": "ATSAM4E8E.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "zephyr",
+    "arduinoCortexM4"
+  ],
+  "name": "Generic ATSAM4E",
+  "upload": {
+    "disable_flushing": true,
+    "maximum_ram_size": 98304,
+    "maximum_size": 524288,
+    "native_usb": true,
+    "protocol": "sam-ba",
+    "protocols": [
+      "sam-ba"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATsam4e8e",
+  "vendor": "Microchip"
+}

--- a/examples/baremetal-blink/README.md
+++ b/examples/baremetal-blink/README.md
@@ -1,0 +1,27 @@
+How to build PlatformIO based project
+=====================================
+
+1. [Install PlatformIO Core](https://docs.platformio.org/page/core.html)
+2. Download [development platform with examples](https://github.com/platformio/platform-atmelsam/archive/develop.zip)
+3. Extract ZIP archive
+4. Run these commands:
+
+```shell
+# Change directory to example
+$ cd platform-atmelsam/examples/baremetal-blink
+
+# Build project
+$ pio run
+
+# Upload firmware
+$ pio run --target upload
+
+# Build specific environment
+$ pio run -e sam4e_baremetal
+
+# Upload firmware for the specific environment
+$ pio run -e sam4e_baremetal --target upload
+
+# Clean build files
+$ pio run --target clean
+```

--- a/examples/baremetal-blink/extra_script.py
+++ b/examples/baremetal-blink/extra_script.py
@@ -1,0 +1,12 @@
+Import("env")
+
+#
+# Dump build environment (for debug)
+# print(env.Dump())
+#
+
+env.Append(
+  LINKFLAGS=[
+      "-Tsrc/variant/linker_scripts/gcc/flash.ld",
+  ]
+)

--- a/examples/baremetal-blink/platformio.ini
+++ b/examples/baremetal-blink/platformio.ini
@@ -1,0 +1,19 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter, extra scripting
+;   Upload options: custom port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;
+; Please visit documentation for the other options and examples
+; http://docs.platformio.org/page/projectconf.html
+
+
+[env:sam4e_baremetal]
+platform = https://github.com/chepo92/platform-atmelsam.git#ArduinoCustomPlatformFrameCore
+;framework = (baremetal)
+board = sam4e8e_baremetal
+platform_packages =
+    toolchain-gccarmnoneeabi @ 1.40804.0
+extra_scripts = extra_script.py    
+
+

--- a/examples/baremetal-blink/src/main.cpp
+++ b/examples/baremetal-blink/src/main.cpp
@@ -1,0 +1,66 @@
+/* ========================================================================== */
+/*                                                                            */
+/*   startup.c  main.c                                                        */
+/*   (c) 2017 Bob Cousins                                                     */
+/*                                                                            */
+/*   2023 Axel Sepulveda gh@chepo92                                           */
+/*   Description                                                              */
+/*                                                                            */
+/*   Minimal blink for SAM4E in platformio using no framework (baremetal)     */
+/* ========================================================================== */
+
+
+#include <stdint.h>
+#include "pio.h"
+#include "variant.h"
+
+
+void HardwareInit (void)
+{
+  // enable peripheral clock
+	//  PMC_WPMR  = PMC_WPKEY << 8 | 0;
+  PMC_PCER0 = 1 << ID_PIOE;  // PIO Clock on E
+
+  // PIOC
+	//  PIOC_WPMR  = PIO_WPKEY << 8 | 0;
+
+  PIOE->PIO_PER = 1 << LED_PIN;
+  PIOE->PIO_OER = 1 << LED_PIN;
+  PIOE->PIO_OWER = 1 << LED_PIN;
+}
+
+static uint32_t* const WDT_MR = (uint32_t*) 0x400E1854;     //  Watchdog Timer Mode Register SAM4: 0x400E1854  SAM3: 0x400E1A54
+
+
+int main()
+{
+  // watchdog timer is actived on boot with a default timeout so disable it
+  // note: you can only write to WDT_MR once after power on reset
+  // Atmel SAM3X8E Datasheet, section 15.4, page 261
+  // Atmel SAM4E8E Datasheet, section 16.5.2, page 362
+  *WDT_MR |= (1 << 15); // WDDIS (watchdog disable) bit, SAM3 page 265, SAM 4 page 362
+
+
+  HardwareInit ();
+
+/*
+ * Blink
+ * Turns on an LED on for one second,
+ * then off for one second, repeatedly.
+ */
+
+	for (;;)
+	{
+      PIOE->PIO_SODR = 1 << LED_PIN;
+      delay (50000);
+      PIOE->PIO_CODR = 1 << LED_PIN;
+      delay (50000);  
+	}
+
+	return 0 ; 
+  
+}
+
+
+
+

--- a/examples/baremetal-blink/src/pio.h
+++ b/examples/baremetal-blink/src/pio.h
@@ -1,0 +1,81 @@
+/* ========================================================================== */
+/*                                                                            */
+/*   startup.c  main.c                                                        */
+/*   (c) 2017 Bob Cousins                                                     */
+/*                                                                            */
+/*   2023 Axel Sepulveda gh@chepo92                                           */
+/*   Description                                                              */
+/*                                                                            */
+/*   Minimal blink for SAM4E in platformio using no framework (baremetal)     */
+/* ========================================================================== */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// PIO definitions
+// Parallel Input/Output Controller (PIO) User Interface
+// You can see that consecutive 32 bit registers are mapped at 4 bytes increments. 
+// 0x0004 bytes = 4*8 = 32 bit
+
+// typedef  struct { } gpio  alternative as in \system\CMSIS\Device\ATMEL\sam4e\include\component\pio.h
+// extern struct gpio {
+struct gpio {
+  // + 0x00
+  volatile uint32_t PIO_PER;      // PIO Enable Register
+  volatile uint32_t PIO_PDR;      // PIO Disable Register
+  volatile uint32_t PIO_PSR;      // PIO Status Register 
+  volatile uint32_t res1;
+  // + 0x10
+  volatile uint32_t PIO_OER;
+  volatile uint32_t PIO_ODR;
+  volatile uint32_t PIO_OSR;
+  volatile uint32_t res2;
+  // + 0x20
+  volatile uint32_t PIO_IFER;
+  volatile uint32_t PIO_IFDR;
+  volatile uint32_t PIO_IFSR;
+  volatile uint32_t res3;
+  // + 0x30
+  volatile uint32_t PIO_SODR;
+  volatile uint32_t PIO_CODR;
+  volatile uint32_t PIO_ODSR;
+  volatile uint32_t PIO_PDSR;
+  // + 0x40
+  volatile uint32_t PIO_IER;
+  volatile uint32_t PIO_IDR;
+  volatile uint32_t PIO_IMR;
+  volatile uint32_t PIO_ISR;
+  // + 0x50
+  volatile uint32_t PIO_MDER;
+  volatile uint32_t PIO_MDDR;
+  volatile uint32_t PIO_MDSR;
+  volatile uint32_t res4;
+  // + 0x60
+  volatile uint32_t PIO_PUDR;
+  volatile uint32_t PIO_PUER;
+  volatile uint32_t PIO_PUSR;
+  volatile uint32_t res5;
+  // + 0x70
+  volatile uint32_t PIO_ABCDSR1;    // SAM4E Table 33-5. Register Mapping (Continued), SAM3: PIO_ABSR
+  volatile uint32_t PIO_ABCDSR2;    // SAM4E Table 33-5. Register Mapping (Continued), SAM3: reserved
+  volatile uint32_t res6[2];
+  // + 0x80
+  volatile uint32_t PIO_SCIFSR;
+  volatile uint32_t PIO_DIFSR;
+  volatile uint32_t PIO_IFDGSR;
+  volatile uint32_t PIO_SCDR;
+  // + 0x90
+  volatile uint32_t res7[4];
+  // + 0xA0
+  volatile uint32_t PIO_OWER;
+  volatile uint32_t PIO_OWDR;
+  volatile uint32_t PIO_OWSR;
+  volatile uint32_t res8;
+  // ...
+} ;
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/examples/baremetal-blink/src/variant.cpp
+++ b/examples/baremetal-blink/src/variant.cpp
@@ -1,0 +1,110 @@
+/* ========================================================================== */
+/*                                                                            */
+/*   startup.c  main.c                                                        */
+/*   (c) 2017 Bob Cousins                                                     */
+/*                                                                            */
+/*   2023 Axel Sepulveda gh@chepo92                                           */
+/*   Description                                                              */
+/*                                                                            */
+/*   Minimal blink for SAM4E in platformio using no framework (baremetal)     */
+/* ========================================================================== */
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#define SCB_VTOR_ADDR 0xE000ED08    // Same for SAM3/4
+
+#define SCB_VTOR *(volatile uint32_t *)SCB_VTOR_ADDR
+
+// These must be defned in linker file
+extern unsigned long _etext;
+extern unsigned long _srelocate;
+extern unsigned long _erelocate;
+extern unsigned long _sbss;
+extern unsigned long _ebss;
+extern unsigned long _estack;
+
+extern int main(void);
+
+typedef void( *const intfunc )( void );
+
+void Reset_Handler(void) __attribute__((__interrupt__));
+void Default_Handler(void);
+
+#define NMI_Handler         Default_Handler
+#define HardFault_Handler   Default_Handler
+#define MemManage_Handler   Default_Handler
+#define BusFault_Handler    Default_Handler
+#define UsageFault_Handler  Default_Handler
+#define MemManage_Handler   Default_Handler
+#define SVC_Handler         Default_Handler
+#define DebugMon_Handler    Default_Handler
+#define PendSV_Handler      Default_Handler
+#define SysTick_Handler     Default_Handler
+
+
+__attribute__ ((section(".vectors")))
+void (* const g_pfnVectors[])(void) = {
+    (intfunc)((unsigned long)&_estack), /* The stack pointer after relocation */
+    Reset_Handler,              /* Reset Handler */
+    NMI_Handler,                /* NMI Handler */
+    HardFault_Handler,          /* Hard Fault Handler */
+    MemManage_Handler,          /* MPU Fault Handler */
+    BusFault_Handler,           /* Bus Fault Handler */
+    UsageFault_Handler,         /* Usage Fault Handler */
+    0,                          /* Reserved */
+    0,                          /* Reserved */
+    0,                          /* Reserved */
+    0,                          /* Reserved */
+    SVC_Handler,                /* SVCall Handler */
+    DebugMon_Handler,           /* Debug Monitor Handler */
+    0,                          /* Reserved */
+    PendSV_Handler,             /* PendSV Handler */
+    SysTick_Handler             /* SysTick Handler */
+};
+
+void Reset_Handler(void)
+{
+    /* Init Data:
+     * - Loads data from addresses defined in linker file into RAM
+     * - Zero bss (statically allocated uninitialized variables)
+     */
+    unsigned long *src, *dst;
+
+    /* copy the data segment into ram */
+    src = &_etext;
+    dst = &_srelocate;
+    if (src != dst)
+        while(dst < &_erelocate)
+            *(dst++) = *(src++);
+
+    /* zero the bss segment */
+    dst = &_sbss;
+    while(dst < &_ebss)
+        *(dst++) = 0;
+
+    SCB_VTOR = ((uint32_t)g_pfnVectors & (uint32_t)0x1FFFFF80);
+
+    main();
+    while(1) {}
+}
+
+void Default_Handler(void)
+{
+    while (1) {}
+}
+
+void delay (volatile uint32_t time)
+{
+  while (time--)
+    __asm ("nop");
+}
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/examples/baremetal-blink/src/variant.h
+++ b/examples/baremetal-blink/src/variant.h
@@ -1,0 +1,59 @@
+/* ========================================================================== */
+/*                                                                            */
+/*   startup.c  main.c                                                        */
+/*   (c) 2017 Bob Cousins                                                     */
+/*                                                                            */
+/*   2023 Axel Sepulveda gh@chepo92                                           */
+/*   Description                                                              */
+/*                                                                            */
+/*   Minimal blink for SAM4E in platformio using no framework (baremetal)     */
+/* ========================================================================== */
+
+#ifndef _VARIANT_SAM4E8E_BAREMETAL // SAM4E8E ( 48 pin  )
+#define _VARIANT_SAM4E8E_BAREMETAL
+
+#ifdef __cplusplus
+extern "C"{
+#endif // __cplusplus
+
+// Output on PE0 (Duet)
+#define LED_PIN 0  // We'll blink pin4 PE0 E2_STOP on Duet Board (refer to Duet schematic https://github.com/Duet3D/Duet-2-Hardware/blob/master/Duet2/Duet2v1.04/Duet2_1.04c_Schematic.pdf)
+
+// PMC definitions
+#define PMC_PCER0 *(volatile uint32_t *)0x400E0410    // PMC Peripheral Clock Enable Register 0; Address SAM3: 0x400E0610 SAM4E: 0x400E0410
+
+// Peripheral Identifiers SAM4E
+#define ID_PIOA 9
+#define ID_PIOB 10
+#define ID_PIOC 11
+#define ID_PIOD 12
+#define ID_PIOE 13
+
+#define PMC_WPMR *(volatile uint32_t *)0x400E06E4 // SAM3: 0x400E06E4 SAM4: 0x400E04E4
+
+#define PMC_WPKEY 0x504D43  // 0/1 = Disables/Enables the Write Protect if WPKEY corresponds to 0x504D43 (“PMC” in ASCII)
+
+#define PIOA ((struct gpio *)0x400E0E00)
+#define PIOB ((struct gpio *)0x400E1000)
+#define PIOC ((struct gpio *)0x400E1200)
+#define PIOD ((struct gpio *)0x400E1400)
+#define PIOE ((struct gpio *)0x400E1600)
+// #define PIOF ((struct gpio *)0x400E1800)  // SAM4 has no PIOF
+
+#define PIOA_WPMR *(volatile uint32_t *)0x400E0EE4
+#define PIOB_WPMR *(volatile uint32_t *)0x400E10E4
+#define PIOC_WPMR *(volatile uint32_t *)0x400E12E4
+#define PIOD_WPMR *(volatile uint32_t *)0x400E14E4
+#define PIOE_WPMR *(volatile uint32_t *)0x400E16E4
+// #define PIOE_WPMR *(volatile uint32_t *)0x400E18E4  // SAM4 has no PIOF, SAM3 was missing
+
+#define PIO_WPKEY 0x50494F // 0/1: Disables/Enables the Write Protect if WPKEY corresponds to 0x50494F (“PIO” in ASCII).
+
+extern void delay( uint32_t dwMs ) ; // From arduino wiring
+
+#ifdef __cplusplus
+} // extern "C"
+
+#endif // __cplusplus
+
+#endif /* _VARIANT_SAM4E8E_BAREMETAL */

--- a/examples/baremetal-blink/src/variant/linker_scripts/gcc/flash.ld
+++ b/examples/baremetal-blink/src/variant/linker_scripts/gcc/flash.ld
@@ -1,0 +1,156 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) 2014, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+/*------------------------------------------------------------------------------
+ *      Linker script for running in internal FLASH on the ATSAM4E
+ *----------------------------------------------------------------------------*/
+
+OUTPUT_FORMAT("elf32-littlearm", "elf32-littlearm", "elf32-littlearm")
+OUTPUT_ARCH(arm)
+SEARCH_DIR(.)
+
+/* Memory Spaces Definitions */
+MEMORY
+{
+  rom (rx)  : ORIGIN = 0x00400000, LENGTH = 0x00080000  /* Flash, 512K for SAM4E 8E/8C*/
+  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00020000  /* sram, 128K */
+}
+
+/* The stack size used by the application. NOTE: you need to adjust according to your application. */
+STACK_SIZE = DEFINED(STACK_SIZE) ? STACK_SIZE : 0x2000;
+
+/* The heapsize used by the application. NOTE: you need to adjust according to your application. */
+/*HEAP_SIZE = DEFINED(HEAP_SIZE) ? HEAP_SIZE : 0x200;*/
+
+/* The stack size used by the application. NOTE: you need to adjust  */
+
+/*__stack_size__ = DEFINED(__stack_size__) ? __stack_size__ : 0x400;*/
+/*__ram_end__ = ORIGIN(ram) + LENGTH(ram) - 4;*/
+
+
+
+/* Section Definitions */
+SECTIONS
+{
+    .text :
+    {
+        . = ALIGN(4);
+        _sfixed = .;
+        KEEP(*(.vectors .vectors.*))
+        *(.text .text.* .gnu.linkonce.t.*)
+        *(.glue_7t) *(.glue_7)
+        *(.rodata .rodata* .gnu.linkonce.r.*)
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+
+        /* Support C constructors, and C destructors in both user code
+           and the C library. This also provides support for C++ code. */
+        . = ALIGN(4);
+        KEEP(*(.init))
+        . = ALIGN(4);
+        __preinit_array_start = .;
+        KEEP (*(.preinit_array))
+        __preinit_array_end = .;
+
+        . = ALIGN(4);
+        __init_array_start = .;
+        KEEP (*(SORT(.init_array.*)))
+        KEEP (*(.init_array))
+        __init_array_end = .;
+
+        . = ALIGN(0x4);
+        KEEP (*crtbegin.o(.ctors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+        KEEP (*(SORT(.ctors.*)))
+        KEEP (*crtend.o(.ctors))
+
+        . = ALIGN(4);
+        KEEP(*(.fini))
+
+        . = ALIGN(4);
+        __fini_array_start = .;
+        KEEP (*(.fini_array))
+        KEEP (*(SORT(.fini_array.*)))
+        __fini_array_end = .;
+
+        KEEP (*crtbegin.o(.dtors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+        KEEP (*(SORT(.dtors.*)))
+        KEEP (*crtend.o(.dtors))
+
+        . = ALIGN(4);
+        _efixed = .;            /* End of text section */
+    } > rom
+
+    /* .ARM.exidx is sorted, so has to go in its own output section.  */
+    PROVIDE_HIDDEN (__exidx_start = .);
+    .ARM.exidx :
+    {
+      *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > rom
+    PROVIDE_HIDDEN (__exidx_end = .);
+
+    . = ALIGN(4);
+    _etext = .;
+
+    .relocate : AT (_etext)
+    {
+        . = ALIGN(4);
+        _srelocate = .;
+        *(.ramfunc .ramfunc.*);
+        *(.data .data.*);
+        . = ALIGN(4);
+        _erelocate = .;
+    } > ram
+
+    /* .bss section which is used for uninitialized data */
+    .bss (NOLOAD) :
+    {
+        . = ALIGN(4);
+        _sbss = . ;
+        _szero = .;
+        *(.bss .bss.*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = . ;
+        _ezero = .;
+    } > ram
+
+    /* stack section */
+    .stack (NOLOAD):
+    {
+        . = ALIGN(8);
+        _sstack = .;
+        . = . + STACK_SIZE;
+        . = ALIGN(8);
+        _estack = .;
+    } > ram
+
+    . = ALIGN(4);
+    _end = . ;
+}


### PR DESCRIPTION
Here I add a generic board with SAM4E (sam4e8e) mcu, and a working blink example, it can be reused for other SAM (like SAM3 from arduino DUE, and other SAM4 series: SAM4N SAM4L SAM4S) changing some defs and providing a linker script.

The example is baremetal, so no framework, no CMSIS (but used some definitions from there)

I might come with an arduino core port for this chip series later, if anyone willing to help or test just send a message
