### PR TITLE
Add support for SAM4E and SAM4S (Arduino core)

### DIFF
--- a/boards/sam4e8e.json
+++ b/boards/sam4e8e.json
@@ -5,7 +5,7 @@
     },
     "core": "arduino",
     "cpu": "cortex-m4",
-    "extra_flags": "",
+    "extra_flags": "-D__SAM4E8E__",
     "f_cpu": "120000000L",
     "hwids": [
       [
@@ -15,7 +15,8 @@
     ],
     "mcu": "at91sam4e8e",
     "usb_product": "Atmel SAM4",
-    "variant": "sam4e8e"
+    "variant": "sam4e8e",
+    "libsam" : "libsam_sam4e8e_gcc_rel"
   },
   "debug": {
     "jlink_device": "ATSAM4E8E",

--- a/boards/sam4e8e.json
+++ b/boards/sam4e8e.json
@@ -3,7 +3,7 @@
     "arduino": {
         "ldscript": "flash.ld"
     },
-    "core": "adafruit",
+    "core": "arduino",
     "cpu": "cortex-m4",
     "extra_flags": "",
     "f_cpu": "120000000L",
@@ -13,9 +13,9 @@
         "0x6124"
       ]
     ],
-    "mcu": "atsam4e8e",
+    "mcu": "at91sam4e8e",
     "usb_product": "Atmel SAM4",
-    "variant": "generic_sam4E"
+    "variant": "sam4e8e"
   },
   "debug": {
     "jlink_device": "ATSAM4E8E",
@@ -35,7 +35,9 @@
     "native_usb": true,
     "protocol": "sam-ba",
     "protocols": [
-      "sam-ba"
+      "sam-ba",
+      "jlink",
+      "blackmagic"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": true,

--- a/boards/sam4e8e_generic.json
+++ b/boards/sam4e8e_generic.json
@@ -1,0 +1,46 @@
+{
+  "build": {
+    "arduino": {
+        "ldscript": "flash.ld"
+    },
+    "core": "adafruit",
+    "cpu": "cortex-m4",
+    "extra_flags": "",
+    "f_cpu": "120000000L",
+    "hwids": [
+      [
+        "0x03EB",
+        "0x6124"
+      ]
+    ],
+    "mcu": "atsam4e8e",
+    "usb_product": "Atmel SAM4",
+    "variant": "generic_sam4E"
+  },
+  "debug": {
+    "jlink_device": "ATSAM4E8E",
+    "openocd_chipname": "atsam4E8E",
+    "openocd_target": "at91sam4XXX",
+    "svd_path": "ATSAM4E8E.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "zephyr"
+  ],
+  "name": "Generic ATSAM4E",
+  "upload": {
+    "disable_flushing": true,
+    "maximum_ram_size": 98304,
+    "maximum_size": 524288,
+    "native_usb": true,
+    "protocol": "sam-ba",
+    "protocols": [
+      "sam-ba"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATsam4e8e",
+  "vendor": "Microchip"
+}

--- a/boards/sam4s4a.json
+++ b/boards/sam4s4a.json
@@ -1,0 +1,48 @@
+{
+  "build": {
+    "arduino": {
+        "ldscript": "flash.ld"
+    },
+    "core": "arduino",
+    "cpu": "cortex-m4",
+    "extra_flags": "",
+    "f_cpu": "120000000L",
+    "hwids": [
+      [
+        "0x03EB",
+        "0x6124"
+      ]
+    ],
+    "mcu": "at91sam4s4a",
+    "usb_product": "Atmel SAM4",
+    "variant": "motionbow"
+  },
+  "debug": {
+    "jlink_device": "ATSAM4S4A",
+    "openocd_chipname": "atsam4S4A",
+    "openocd_target": "at91sam4XXX",
+    "svd_path": "ATSAM4S4A.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "zephyr"
+  ],
+  "name": "Generic ATSAM4E",
+  "upload": {
+    "disable_flushing": true,
+    "maximum_ram_size": 98304,
+    "maximum_size": 524288,
+    "native_usb": true,
+    "protocol": "sam-ba",
+    "protocols": [
+      "sam-ba",
+      "jlink",
+      "blackmagic"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATsam4e8e",
+  "vendor": "Microchip"
+}

--- a/boards/sam4s4a.json
+++ b/boards/sam4s4a.json
@@ -5,7 +5,7 @@
     },
     "core": "arduino",
     "cpu": "cortex-m4",
-    "extra_flags": "",
+    "extra_flags": "-D__SAM4S4A__",
     "f_cpu": "120000000L",
     "hwids": [
       [
@@ -15,7 +15,8 @@
     ],
     "mcu": "at91sam4s4a",
     "usb_product": "Atmel SAM4",
-    "variant": "motionbow"
+    "variant": "motionbow",
+    "libsam" : "libsam_sam4s4a_gcc_rel"
   },
   "debug": {
     "jlink_device": "ATSAM4S4A",

--- a/builder/frameworks/arduino/arduino-sam.py
+++ b/builder/frameworks/arduino/arduino-sam.py
@@ -40,6 +40,11 @@ SYSTEM_DIR = os.path.join(FRAMEWORK_DIR, "system")
 assert os.path.isdir(SYSTEM_DIR)
 assert os.path.isdir(FRAMEWORK_DIR)
 
+if "build.libsam" in board:
+    libsam_name = board.get("build.libsam", "")
+else: 
+    libsam_name = "sam_sam3x8e_gcc_rel"
+
 env.SConscript("arduino-common.py")
 
 env.Append(
@@ -61,7 +66,7 @@ env.Append(
         "-u", "_getpid"
     ],
 
-    LIBS=["sam_sam3x8e_gcc_rel", "gcc"]
+    LIBS=[libsam_name, "gcc"]
 )
 
 #

--- a/examples/arduino-blink/platformio.ini
+++ b/examples/arduino-blink/platformio.ini
@@ -123,11 +123,8 @@ board = seeed_wio_lite_mg126
 framework = arduino
 
 [env:sam4e8e]
-; This branch, should point to atmelsam when merged
-platform = https://github.com/chepo92/platform-atmelsam.git#arduino-core-sam4e-4s 
+platform = atmelsam
 board = sam4e8e
 framework = arduino
 platform_packages =
-  ; framework-arduino-sam to be merged into upstream
-  framework-arduino-sam @ https://github.com/chepo92/ArduinoCore-sam.git#dev-SAM4E
   toolchain-gccarmnoneeabi @ 1.40804.0

--- a/examples/arduino-blink/platformio.ini
+++ b/examples/arduino-blink/platformio.ini
@@ -123,6 +123,6 @@ board = seeed_wio_lite_mg126
 framework = arduino
 
 [env:sam4e8e]
-platform = https://github.com/chepo92/platform-atmelsam.git
+platform = https://github.com/chepo92/platform-atmelsam.git#arduino-core-sam4e-4s
 board = sam4e8e
 framework = https://github.com/chepo92/ArduinoCore-sam.git#dev-SAM4E

--- a/examples/arduino-blink/platformio.ini
+++ b/examples/arduino-blink/platformio.ini
@@ -7,20 +7,20 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-; [env:adafruit_circuitplayground_m0]
-; platform = atmelsam
-; framework = arduino
-; board = adafruit_circuitplayground_m0
+[env:adafruit_circuitplayground_m0]
+platform = atmelsam
+framework = arduino
+board = adafruit_circuitplayground_m0
 
-; [env:adafruit_feather_m0]
-; platform = atmelsam
-; framework = arduino
-; board = adafruit_feather_m0
+[env:adafruit_feather_m0]
+platform = atmelsam
+framework = arduino
+board = adafruit_feather_m0
 
-; [env:adafruit_metro_m4]
-; platform = atmelsam
-; framework = arduino
-; board = adafruit_metro_m4
+[env:adafruit_metro_m4]
+platform = atmelsam
+framework = arduino
+board = adafruit_metro_m4
 
 [env:due]
 platform = atmelsam
@@ -32,101 +32,102 @@ platform = atmelsam
 framework = arduino
 board = dueUSB
 
-; [env:digix]
-; platform = atmelsam
-; framework = arduino
-; board = digix
+[env:digix]
+platform = atmelsam
+framework = arduino
+board = digix
 
-; [env:mkr1000USB]
-; platform = atmelsam
-; framework = arduino
-; board = mkr1000USB
+[env:mkr1000USB]
+platform = atmelsam
+framework = arduino
+board = mkr1000USB
 
-; [env:mkrzero]
-; platform = atmelsam
-; framework = arduino
-; board = mkrzero
+[env:mkrzero]
+platform = atmelsam
+framework = arduino
+board = mkrzero
 
-; [env:mzeropro]
-; platform = atmelsam
-; framework = arduino
-; board = mzeropro
+[env:mzeropro]
+platform = atmelsam
+framework = arduino
+board = mzeropro
 
-; [env:mzeroUSB]
-; platform = atmelsam
-; framework = arduino
-; board = mzeroUSB
+[env:mzeroUSB]
+platform = atmelsam
+framework = arduino
+board = mzeroUSB
 
-; [env:sodaq_autonomo]
-; platform = atmelsam
-; framework = arduino
-; board = sodaq_autonomo
+[env:sodaq_autonomo]
+platform = atmelsam
+framework = arduino
+board = sodaq_autonomo
 
-; [env:sparkfun_samd21_mini_usb]
-; platform = atmelsam
-; framework = arduino
-; board = sparkfun_samd21_mini_usb
+[env:sparkfun_samd21_mini_usb]
+platform = atmelsam
+framework = arduino
+board = sparkfun_samd21_mini_usb
 
-; [env:sparkfun_samd51_thing_plus]
-; platform = atmelsam
-; framework = arduino
-; board = sparkfun_samd51_thing_plus
+[env:sparkfun_samd51_thing_plus]
+platform = atmelsam
+framework = arduino
+board = sparkfun_samd51_thing_plus
 
-; [env:tian]
-; platform = atmelsam
-; framework = arduino
-; board = tian
+[env:tian]
+platform = atmelsam
+framework = arduino
+board = tian
 
-; [env:zero]
-; platform = atmelsam
-; framework = arduino
-; board = zero
+[env:zero]
+platform = atmelsam
+framework = arduino
+board = zero
 
-; [env:zeroUSB]
-; platform = atmelsam
-; framework = arduino
-; board = zeroUSB
+[env:zeroUSB]
+platform = atmelsam
+framework = arduino
+board = zeroUSB
 
-; [env:current_ranger]
-; platform = atmelsam
-; framework = arduino
-; board = current_ranger
+[env:current_ranger]
+platform = atmelsam
+framework = arduino
+board = current_ranger
 
-; [env:minitronics20]
-; platform = atmelsam
-; framework = arduino
-; board = minitronics20
+[env:minitronics20]
+platform = atmelsam
+framework = arduino
+board = minitronics20
 
-; [env:seeed_wio_terminal]
-; platform = atmelsam
-; board = seeed_wio_terminal
-; framework = arduino
+[env:seeed_wio_terminal]
+platform = atmelsam
+board = seeed_wio_terminal
+framework = arduino
 
-; [env:seeed_xiao]
-; platform = atmelsam
-; board = seeed_xiao
-; framework = arduino
+[env:seeed_xiao]
+platform = atmelsam
+board = seeed_xiao
+framework = arduino
 
-; [env:seeed_femto]
-; platform = atmelsam
-; board = seeed_femto
-; framework = arduino
+[env:seeed_femto]
+platform = atmelsam
+board = seeed_femto
+framework = arduino
 
-; [env:seeed_zero]
-; platform = atmelsam
-; board = seeed_zero
-; framework = arduino
+[env:seeed_zero]
+platform = atmelsam
+board = seeed_zero
+framework = arduino
 
-; [env:seeed_wio_lite_mg126]
-; platform = atmelsam
-; board = seeed_wio_lite_mg126
-; framework = arduino
+[env:seeed_wio_lite_mg126]
+platform = atmelsam
+board = seeed_wio_lite_mg126
+framework = arduino
 
 [env:sam4e8e]
-platform = https://github.com/chepo92/platform-atmelsam.git#arduino-core-sam4e-4s
+; This branch, should point to atmelsam when merged
+platform = https://github.com/chepo92/platform-atmelsam.git#arduino-core-sam4e-4s 
 board = sam4e8e
 framework = arduino
 platform_packages =
+  ; framework-arduino-sam to be merged into upstream
   framework-arduino-sam @ https://github.com/chepo92/ArduinoCore-sam.git#dev-SAM4E
   toolchain-gccarmnoneeabi @ 1.40804.0
-  framework-cmsis-atmel @ https://github.com/chepo92/ArduinoModule-CMSIS-Atmel.git#dev-sam4e-mods

--- a/examples/arduino-blink/platformio.ini
+++ b/examples/arduino-blink/platformio.ini
@@ -7,20 +7,20 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:adafruit_circuitplayground_m0]
-platform = atmelsam
-framework = arduino
-board = adafruit_circuitplayground_m0
+; [env:adafruit_circuitplayground_m0]
+; platform = atmelsam
+; framework = arduino
+; board = adafruit_circuitplayground_m0
 
-[env:adafruit_feather_m0]
-platform = atmelsam
-framework = arduino
-board = adafruit_feather_m0
+; [env:adafruit_feather_m0]
+; platform = atmelsam
+; framework = arduino
+; board = adafruit_feather_m0
 
-[env:adafruit_metro_m4]
-platform = atmelsam
-framework = arduino
-board = adafruit_metro_m4
+; [env:adafruit_metro_m4]
+; platform = atmelsam
+; framework = arduino
+; board = adafruit_metro_m4
 
 [env:due]
 platform = atmelsam
@@ -32,97 +32,101 @@ platform = atmelsam
 framework = arduino
 board = dueUSB
 
-[env:digix]
-platform = atmelsam
-framework = arduino
-board = digix
+; [env:digix]
+; platform = atmelsam
+; framework = arduino
+; board = digix
 
-[env:mkr1000USB]
-platform = atmelsam
-framework = arduino
-board = mkr1000USB
+; [env:mkr1000USB]
+; platform = atmelsam
+; framework = arduino
+; board = mkr1000USB
 
-[env:mkrzero]
-platform = atmelsam
-framework = arduino
-board = mkrzero
+; [env:mkrzero]
+; platform = atmelsam
+; framework = arduino
+; board = mkrzero
 
-[env:mzeropro]
-platform = atmelsam
-framework = arduino
-board = mzeropro
+; [env:mzeropro]
+; platform = atmelsam
+; framework = arduino
+; board = mzeropro
 
-[env:mzeroUSB]
-platform = atmelsam
-framework = arduino
-board = mzeroUSB
+; [env:mzeroUSB]
+; platform = atmelsam
+; framework = arduino
+; board = mzeroUSB
 
-[env:sodaq_autonomo]
-platform = atmelsam
-framework = arduino
-board = sodaq_autonomo
+; [env:sodaq_autonomo]
+; platform = atmelsam
+; framework = arduino
+; board = sodaq_autonomo
 
-[env:sparkfun_samd21_mini_usb]
-platform = atmelsam
-framework = arduino
-board = sparkfun_samd21_mini_usb
+; [env:sparkfun_samd21_mini_usb]
+; platform = atmelsam
+; framework = arduino
+; board = sparkfun_samd21_mini_usb
 
-[env:sparkfun_samd51_thing_plus]
-platform = atmelsam
-framework = arduino
-board = sparkfun_samd51_thing_plus
+; [env:sparkfun_samd51_thing_plus]
+; platform = atmelsam
+; framework = arduino
+; board = sparkfun_samd51_thing_plus
 
-[env:tian]
-platform = atmelsam
-framework = arduino
-board = tian
+; [env:tian]
+; platform = atmelsam
+; framework = arduino
+; board = tian
 
-[env:zero]
-platform = atmelsam
-framework = arduino
-board = zero
+; [env:zero]
+; platform = atmelsam
+; framework = arduino
+; board = zero
 
-[env:zeroUSB]
-platform = atmelsam
-framework = arduino
-board = zeroUSB
+; [env:zeroUSB]
+; platform = atmelsam
+; framework = arduino
+; board = zeroUSB
 
-[env:current_ranger]
-platform = atmelsam
-framework = arduino
-board = current_ranger
+; [env:current_ranger]
+; platform = atmelsam
+; framework = arduino
+; board = current_ranger
 
-[env:minitronics20]
-platform = atmelsam
-framework = arduino
-board = minitronics20
+; [env:minitronics20]
+; platform = atmelsam
+; framework = arduino
+; board = minitronics20
 
-[env:seeed_wio_terminal]
-platform = atmelsam
-board = seeed_wio_terminal
-framework = arduino
+; [env:seeed_wio_terminal]
+; platform = atmelsam
+; board = seeed_wio_terminal
+; framework = arduino
 
-[env:seeed_xiao]
-platform = atmelsam
-board = seeed_xiao
-framework = arduino
+; [env:seeed_xiao]
+; platform = atmelsam
+; board = seeed_xiao
+; framework = arduino
 
-[env:seeed_femto]
-platform = atmelsam
-board = seeed_femto
-framework = arduino
+; [env:seeed_femto]
+; platform = atmelsam
+; board = seeed_femto
+; framework = arduino
 
-[env:seeed_zero]
-platform = atmelsam
-board = seeed_zero
-framework = arduino
+; [env:seeed_zero]
+; platform = atmelsam
+; board = seeed_zero
+; framework = arduino
 
-[env:seeed_wio_lite_mg126]
-platform = atmelsam
-board = seeed_wio_lite_mg126
-framework = arduino
+; [env:seeed_wio_lite_mg126]
+; platform = atmelsam
+; board = seeed_wio_lite_mg126
+; framework = arduino
 
 [env:sam4e8e]
 platform = https://github.com/chepo92/platform-atmelsam.git#arduino-core-sam4e-4s
 board = sam4e8e
-framework = https://github.com/chepo92/ArduinoCore-sam.git#dev-SAM4E
+framework = arduino
+platform_packages =
+  framework-arduino-sam @ https://github.com/chepo92/ArduinoCore-sam.git#dev-SAM4E
+  toolchain-gccarmnoneeabi @ 1.40804.0
+  framework-cmsis-atmel @ https://github.com/chepo92/ArduinoModule-CMSIS-Atmel.git#dev-sam4e-mods

--- a/examples/arduino-blink/platformio.ini
+++ b/examples/arduino-blink/platformio.ini
@@ -121,3 +121,8 @@ framework = arduino
 platform = atmelsam
 board = seeed_wio_lite_mg126
 framework = arduino
+
+[env:sam4e8e]
+platform = https://github.com/chepo92/platform-atmelsam.git
+board = sam4e8e
+framework = https://github.com/chepo92/ArduinoCore-sam.git#dev-SAM4E


### PR DESCRIPTION
Added support for SAM4E and SAM4S series with arduino core, it will need some further work to enable all peripherals in SAM4E, port is mostly based on SAM4S/SAM4E ports from:
- https://github.com/Daniel-dk/motionbow 
- https://github.com/aethaniel/ExperimentalCore-sam
See my other pr for baremetal example and zephyr os support example

ACK:
FlutterWireless (USB port)
https://github.com/Daniel-dk for porting SAM4S
https://github.com/aethaniel
