### PR TITLE
update platform include latest framework with Adafruit_TinyUSB

### DIFF
--- a/platform.json
+++ b/platform.json
@@ -20,7 +20,7 @@
     "type": "git",
     "url": "https://github.com/platformio/platform-atmelsam.git"
   },
-  "version": "8.3.0",
+  "version": "8.3.1",
   "frameworks": {
     "arduino": {
       "package": "framework-arduino-sam",
@@ -59,7 +59,7 @@
       "type": "framework",
       "optional": true,
       "owner": "platformio",
-      "version": "~1.10716.0"
+      "version": "~1.7.17"
     },
     "framework-arduino-samd-seeed": {
       "type": "framework",


### PR DESCRIPTION
once https://github.com/adafruit/ArduinoCore-samd/pull/362 is merged this pr will enable latest Adafruit_TinyUSB in framework.