### PR TITLE
Add Telit Charlie board

### DIFF
--- a/boards/telit_charlie.json
+++ b/boards/telit_charlie.json
@@ -1,0 +1,53 @@
+{
+    "build": {
+      "arduino": {
+          "ldscript": "flash_with_bootloader.ld"
+      },
+      "core": "telit",
+      "cpu": "cortex-m0plus",
+      "extra_flags": "-DARDUINO_TELIT_SAMD_CHARLIE -D__SAMD21G18A__",
+      "f_cpu": "48000000L",
+      "hwids": [
+        [
+          "0x04d8",
+          "0xeaab"
+        ],
+        [
+          "0x04d8",
+          "0xeb97"
+        ]
+      ],
+      "mcu": "samd21g18a",
+      "usb_product": "Telit Charlie Board",
+      "variant": "charlie"
+    },
+    "debug": {
+      "jlink_device": "ATSAMD21G18",
+      "openocd_chipname": "at91samd21g18",
+      "openocd_target": "at91samdXX",
+      "svd_path": "ATSAMD21G18A.svd"
+    },
+    "frameworks": [
+      "arduino"
+    ],
+    "name": "Telit-Charlie",
+    "upload": {
+      "disable_flushing": true,
+      "maximum_ram_size": 32768,
+      "maximum_size": 262144,
+      "native_usb": true,
+      "offset_address": "0x2000",
+      "protocol": "sam-ba",
+      "protocols": [
+        "sam-ba",
+        "blackmagic",
+        "jlink",
+        "atmel-ice"
+      ],
+      "require_upload_port": true,
+      "use_1200bps_touch": true,
+      "wait_for_upload_port": true
+    },
+    "url": "https://www.telit.com/support-tools/development-evaluation-kits/charlie-evaluation-kit-for-cellular-lpwa/",
+    "vendor": "Telit"
+  }

--- a/builder/frameworks/arduino/arduino-samd.py
+++ b/builder/frameworks/arduino/arduino-samd.py
@@ -46,6 +46,8 @@ env.SConscript("arduino-common.py")
 BUILD_CORE = "arduino"
 if VENDOR_CORE == "sparkfun" and board.get("build.mcu", "").startswith("samd51"):
     BUILD_CORE = "arduino51"
+if VENDOR_CORE == "telit":
+    BUILD_CORE = "def"
 
 env.Append(
     CPPDEFINES=[

--- a/examples/arduino-blink/platformio.ini
+++ b/examples/arduino-blink/platformio.ini
@@ -121,3 +121,8 @@ framework = arduino
 platform = atmelsam
 board = seeed_wio_lite_mg126
 framework = arduino
+
+[env:telit_charlie]
+platform = atmelsam
+board = telit_charlie
+framework = arduino

--- a/platform.json
+++ b/platform.json
@@ -97,6 +97,12 @@
       "owner": "platformio",
       "version": "~1.0.6"
     },
+    "framework-arduino-samd-telit": {
+      "type": "framework",
+      "optional": true,
+      "owner": "platformio",
+      "version": "https://github.com/maxgerhardt/arduino-charlie/archive/refs/tags/1.0.4.zip"
+    },
     "framework-cmsis": {
       "type": "framework",
       "optional": true,

--- a/platform.py
+++ b/platform.py
@@ -69,7 +69,12 @@ class AtmelsamPlatform(PlatformBase):
                 self.packages["toolchain-gccarmnoneeabi"]["version"] = "~1.90301.0"
             if build_core in ("adafruit", "seeed"):
                 self.packages["framework-cmsis"]["version"] = "~2.50400.0"
-
+            if build_core == "telit":
+                self.packages["toolchain-gccarmnoneeabi"][
+                    "version"] = "~1.70201.0"
+                self.packages["tool-bossac"]["version"] = "~1.10700.0"
+                self.packages["framework-cmsis"]["version"] = "~1.40500.0"
+                self.packages["framework-cmsis-atmel"]["version"] = "~1.2.0"
         if (
             board.get("build.core", "") in ("adafruit", "seeed", "sparkfun")
             and "tool-bossac" in self.packages


### PR DESCRIPTION
Adds support for https://github.com/telit/arduino-charlie and its only board: The [Telit Charlie Board](https://www.telit.com/support-tools/development-evaluation-kits/charlie-evaluation-kit-for-cellular-lpwa/).

Proven to be working on real hardware in [community topic](https://community.platformio.org/t/tips-for-adding-an-arduino-compatible-board-to-platformio/41902/3?u=maxgerhardt).

(Please add `framework-arduino-samd-telit` to the PIO registry as needed.)