### PR TITLE
Add global support for custom boards variants directory.

### DIFF
--- a/builder/frameworks/arduino/arduino-common.py
+++ b/builder/frameworks/arduino/arduino-common.py
@@ -27,6 +27,7 @@ import os
 from SCons.Script import DefaultEnvironment
 
 env = DefaultEnvironment()
+config = env.GetProjectConfig()
 platform = env.PioPlatform()
 board = env.BoardConfig()
 build_mcu = env.get("BOARD_MCU", board.get("build.mcu", ""))
@@ -95,9 +96,16 @@ env.Append(
     LIBS=["m"]
 )
 
-variants_dir = os.path.join(
-    "$PROJECT_DIR", board.get("build.variants_dir")) if board.get(
-        "build.variants_dir", "") else os.path.join(FRAMEWORK_DIR, "variants")
+vardirs = [
+    os.path.join("$PROJECT_DIR", board.get("build.variants_dir")),
+    os.path.join(os.getcwd(), board.get("build.variants_dir")),
+    os.path.join(config.get("platformio", "core_dir"), board.get("build.variants_dir")),
+    os.path.join(os.path.join(FRAMEWORK_DIR, "variants")),
+]
+
+for variants_dir in vardirs:
+    if os.path.isdir(variants_dir):
+        break
 
 if not board.get("build.ldscript", ""):
     env.Append(

--- a/builder/frameworks/arduino/arduino-sam.py
+++ b/builder/frameworks/arduino/arduino-sam.py
@@ -27,6 +27,7 @@ import os
 from SCons.Script import DefaultEnvironment
 
 env = DefaultEnvironment()
+config = env.GetProjectConfig()
 platform = env.PioPlatform()
 board = env.BoardConfig()
 
@@ -71,9 +72,17 @@ env.Append(
 libs = []
 
 if "build.variant" in board:
-    variants_dir = os.path.join(
-        "$PROJECT_DIR", board.get("build.variants_dir")) if board.get(
-            "build.variants_dir", "") else os.path.join(FRAMEWORK_DIR, "variants")
+    vardirs = [
+        os.path.join("$PROJECT_DIR", board.get("build.variants_dir")),
+        os.path.join(os.getcwd(), board.get("build.variants_dir")),
+        os.path.join(config.get("platformio", "core_dir"), board.get("build.variants_dir")),
+        os.path.join(os.path.join(FRAMEWORK_DIR, "variants")),
+    ]
+
+    for variants_dir in vardirs:
+        if os.path.isdir(variants_dir):
+            break
+
     env.Append(
         CPPPATH=[
             os.path.join(variants_dir, board.get("build.variant"))

--- a/builder/frameworks/arduino/arduino-sam.py
+++ b/builder/frameworks/arduino/arduino-sam.py
@@ -24,10 +24,11 @@ http://arduino.cc/en/Reference/HomePage
 
 import os
 
+from arduino_common import get_variants_dir
+
 from SCons.Script import DefaultEnvironment
 
 env = DefaultEnvironment()
-config = env.GetProjectConfig()
 platform = env.PioPlatform()
 board = env.BoardConfig()
 
@@ -41,7 +42,7 @@ SYSTEM_DIR = os.path.join(FRAMEWORK_DIR, "system")
 assert os.path.isdir(SYSTEM_DIR)
 assert os.path.isdir(FRAMEWORK_DIR)
 
-env.SConscript("arduino-common.py")
+env.SConscript("arduino_common.py")
 
 env.Append(
     CPPDEFINES=[
@@ -72,17 +73,7 @@ env.Append(
 libs = []
 
 if "build.variant" in board:
-    vardirs = [
-        os.path.join("$PROJECT_DIR", board.get("build.variants_dir")),
-        os.path.join(os.getcwd(), board.get("build.variants_dir")),
-        os.path.join(config.get("platformio", "core_dir"), board.get("build.variants_dir")),
-        os.path.join(os.path.join(FRAMEWORK_DIR, "variants")),
-    ]
-
-    for variants_dir in vardirs:
-        if os.path.isdir(variants_dir):
-            break
-
+    variants_dir = get_variants_dir()
     env.Append(
         CPPPATH=[
             os.path.join(variants_dir, board.get("build.variant"))

--- a/builder/frameworks/arduino/arduino-samd.py
+++ b/builder/frameworks/arduino/arduino-samd.py
@@ -27,6 +27,7 @@ import os
 from SCons.Script import DefaultEnvironment
 
 env = DefaultEnvironment()
+config = env.GetProjectConfig()
 platform = env.PioPlatform()
 board = env.BoardConfig()
 
@@ -178,9 +179,16 @@ elif VENDOR_CORE == "arduino":
 libs = []
 
 if "build.variant" in board:
-    variants_dir = os.path.join(
-        "$PROJECT_DIR", board.get("build.variants_dir")) if board.get(
-            "build.variants_dir", "") else os.path.join(FRAMEWORK_DIR, "variants")
+    vardirs = [
+        os.path.join("$PROJECT_DIR", board.get("build.variants_dir")),
+        os.path.join(os.getcwd(), board.get("build.variants_dir")),
+        os.path.join(config.get("platformio", "core_dir"), board.get("build.variants_dir")),
+        os.path.join(os.path.join(FRAMEWORK_DIR, "variants")),
+    ]
+
+    for variants_dir in vardirs:
+        if os.path.isdir(variants_dir):
+            break
 
     env.Append(
         CPPPATH=[os.path.join(variants_dir, board.get("build.variant"))]

--- a/builder/frameworks/arduino/arduino-samd.py
+++ b/builder/frameworks/arduino/arduino-samd.py
@@ -24,10 +24,11 @@ http://arduino.cc/en/Reference/HomePage
 
 import os
 
+from arduino_common import get_variants_dir
+
 from SCons.Script import DefaultEnvironment
 
 env = DefaultEnvironment()
-config = env.GetProjectConfig()
 platform = env.PioPlatform()
 board = env.BoardConfig()
 
@@ -42,7 +43,7 @@ CMSIS_ATMEL_DIR = platform.get_package_dir("framework-cmsis-atmel")
 
 assert all(os.path.isdir(d) for d in (FRAMEWORK_DIR, CMSIS_DIR, CMSIS_ATMEL_DIR))
 
-env.SConscript("arduino-common.py")
+env.SConscript("arduino_common.py")
 
 BUILD_CORE = "arduino"
 if VENDOR_CORE == "sparkfun" and board.get("build.mcu", "").startswith("samd51"):
@@ -179,16 +180,7 @@ elif VENDOR_CORE == "arduino":
 libs = []
 
 if "build.variant" in board:
-    vardirs = [
-        os.path.join("$PROJECT_DIR", board.get("build.variants_dir")),
-        os.path.join(os.getcwd(), board.get("build.variants_dir")),
-        os.path.join(config.get("platformio", "core_dir"), board.get("build.variants_dir")),
-        os.path.join(os.path.join(FRAMEWORK_DIR, "variants")),
-    ]
-
-    for variants_dir in vardirs:
-        if os.path.isdir(variants_dir):
-            break
+    variants_dir = get_variants_dir()
 
     env.Append(
         CPPPATH=[os.path.join(variants_dir, board.get("build.variant"))]

--- a/builder/frameworks/arduino/arduino_common.py
+++ b/builder/frameworks/arduino/arduino_common.py
@@ -27,7 +27,6 @@ import os
 from SCons.Script import DefaultEnvironment
 
 env = DefaultEnvironment()
-config = env.GetProjectConfig()
 platform = env.PioPlatform()
 board = env.BoardConfig()
 build_mcu = env.get("BOARD_MCU", board.get("build.mcu", ""))
@@ -42,6 +41,17 @@ if board.get("build.core", "").lower() != "arduino":
 FRAMEWORK_DIR = platform.get_package_dir(framework_package)
 
 assert os.path.isdir(FRAMEWORK_DIR)
+
+
+def get_variants_dir():
+    if "build.variants_dir" not in board:
+        return os.path.join(FRAMEWORK_DIR, "variants")
+
+    if os.path.isabs(env.subst(board.get("build.variants_dir"))):
+        return board.get("build.variants_dir", "")
+
+    return os.path.join("$PROJECT_DIR", board.get("build.variants_dir"))
+
 
 machine_flags = [
     "-mcpu=%s" % board.get("build.cpu"),
@@ -96,26 +106,18 @@ env.Append(
     LIBS=["m"]
 )
 
-vardirs = [
-    os.path.join("$PROJECT_DIR", board.get("build.variants_dir")),
-    os.path.join(os.getcwd(), board.get("build.variants_dir")),
-    os.path.join(config.get("platformio", "core_dir"), board.get("build.variants_dir")),
-    os.path.join(os.path.join(FRAMEWORK_DIR, "variants")),
-]
-
-for variants_dir in vardirs:
-    if os.path.isdir(variants_dir):
-        break
-
 if not board.get("build.ldscript", ""):
     env.Append(
         LIBPATH=[
-            os.path.join(variants_dir, board.get("build.variant"), "linker_scripts", "gcc")
+            os.path.join(
+                get_variants_dir(),
+                board.get("build.variant"),
+                "linker_scripts",
+                "gcc",
+            )
         ]
     )
-    env.Replace(
-        LDSCRIPT_PATH=board.get("build.arduino.ldscript", "")
-    )
+    env.Replace(LDSCRIPT_PATH=board.get("build.arduino.ldscript", ""))
 
 if "build.usb_product" in board:
     env.Append(


### PR DESCRIPTION
The scripts will search for the "variants_dir" directory specified in custom board ".json" file in:
- project root directory
- core_dir
- framework installed "variants"

Tested cases with project and core_dir. When both locations were not present, the script defaulted to `~/.platformio/packages/framework-arduino-samd/variants` as expected