### PR TITLE
Support variant_pkg key

### DIFF
--- a/builder/frameworks/arduino/arduino_common.py
+++ b/builder/frameworks/arduino/arduino_common.py
@@ -44,14 +44,23 @@ assert os.path.isdir(FRAMEWORK_DIR)
 
 
 def get_variants_dir():
-    if "build.variants_dir" not in board:
+    if "build.variants_dir" not in board and "build.variant_pkg" not in board:
         return os.path.join(FRAMEWORK_DIR, "variants")
+    if "build.variants_dir" in board:
+            if os.path.isabs(env.subst(board.get("build.variants_dir"))):
+                return board.get("build.variants_dir", "")
 
-    if os.path.isabs(env.subst(board.get("build.variants_dir"))):
-        return board.get("build.variants_dir", "")
+            return os.path.join("$PROJECT_DIR", board.get("build.variants_dir"))
 
-    return os.path.join("$PROJECT_DIR", board.get("build.variants_dir"))
-
+    elif board.get("build.variant_pkg", ""):
+        full_variant_pkg = (
+            "framework-arduino-"
+            + MCU_FAMILY
+            + "-%s" % board.get("build.variant_pkg").lower()
+        )
+        return os.path.join(
+            platform.get_package_dir(full_variant_pkg), "variants"
+        )
 
 machine_flags = [
     "-mcpu=%s" % board.get("build.cpu"),

--- a/platform.py
+++ b/platform.py
@@ -49,18 +49,31 @@ class AtmelsamPlatform(PlatformBase):
         ).lower()
 
         if "arduino" in variables.get("pioframework", []):
-            framework_package = "framework-arduino-%s" % (
+            framework_mcu = (
                 "sam" if board.get("build.mcu", "").startswith("at91") else "samd"
             )
+            framework_package = "framework-arduino-%s" % (framework_mcu)
 
             if build_core != "arduino":
                 framework_package += "-" + build_core
+
+            variant_package = (
+                "framework-arduino-%s-%s"
+                % (
+                    framework_mcu,
+                    board.get("build.variant_pkg", ""),
+                )
+                if board.get("build.variant_pkg", "")
+                else None
+            )
 
             self.frameworks["arduino"]["package"] = framework_package
             if not board.get("build.mcu", "").startswith("samd"):
                 self.packages["framework-arduino-sam"]["optional"] = True
             if framework_package in self.packages:
                 self.packages[framework_package]["optional"] = False
+            if variant_package and variant_package in self.packages:
+                self.packages[variant_package]["optional"] = False
             self.packages["framework-cmsis"]["optional"] = False
             self.packages["framework-cmsis-atmel"]["optional"] = False
             if build_core in ("tuino0", "reprap"):


### PR DESCRIPTION
This supports a 'variant_pkg' which allows users to create a variant-only package - ie, one that has no core libraries, just the pin definition files.